### PR TITLE
Refactor Qless\Queue:pop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   to the `put(string className, array $data, ?string $jid = null, ...)`
 - Now `Qless\Queue::pop` does not require the mandatory presence of the worker name as its 1st argument.
   If the the worker name is not passed the `Qless\Client::getWorkerName` will be used
+- Now calling `Qless\Queue::pop` without 2nd argument (number of jobs to pop off of the queue) will return
+  `Qless\Job|null` so that there is no need to play with arrays like `$job[0]->function()`
 
 ### Removed
 - Fully refactor the `Qless\Client` class and removed no longer used code

--- a/README.md
+++ b/README.md
@@ -125,15 +125,8 @@ class MyJobClass
 Now you can access a queue, and add a job to that queue.
 
 ```php
-use Qless\Client;
-use Qless\Queue;
-use Qless\Demo\Enqueing\MyJobClass;
-
-// Connect to localhost
-$client = new Client(REDIS_HOST, REDIS_PORT, REDIS_TIMEOUT);
-
 // This references a new or existing queue 'testing'
-$queue = new Queue('testing', $client);
+$queue = new Qless\Queue('testing', $client);
 
 // Let's add a job, with some data. Returns Job ID
 $jid = $queue->put(MyJobClass::class, ['hello' => 'howdy']);
@@ -144,7 +137,7 @@ $job = $queue->pop();
 // $job here is an array of the Qless\Job instances
 
 // And we can do the work associated with it!
-$job[0]->perform();
+$job->perform();
 // Perform 316eb06a-30d2-4d66-ad0d-33361306a7a1 job
 ```
 

--- a/demo/Enqueing/test.php
+++ b/demo/Enqueing/test.php
@@ -20,9 +20,6 @@ $jid = $queue->put(MyJobClass::class, ['hello' => 'howdy']);
 $job = $queue->pop();
 // $job here is an array of the Qless\Job instances
 
-assert(is_array($job));
-assert($job[0] instanceof Qless\Job);
-
 // And we can do the work associated with it!
-$job[0]->perform();
+$job->perform();
 // Perform 316eb06a-30d2-4d66-ad0d-33361306a7a1 job

--- a/src/Worker.php
+++ b/src/Worker.php
@@ -217,15 +217,14 @@ class Worker
         }
     }
 
-    /**
-     * @return null|Job
-     */
+    /** @return null|Job */
     public function reserve(): ?Job
     {
         foreach ($this->queues as $queue) {
+            /** @var \Qless\Job|null $job */
             $job = $queue->pop($this->workerName);
-            if (isset($job[0])) {
-                return $job[0];
+            if ($job !== null) {
+                return $job;
             }
         }
 

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -262,11 +262,9 @@ class ClientTest extends QlessTestCase
         $queue->put('Xxx\Yyy', ['some-data'], 'job-42');
         $this->assertEquals(1, $this->client->length('some-queue-2'));
 
-        $job = $queue->pop('worker-1');
-        $job[0]->complete();
+        $queue->pop()->complete();
 
         $this->assertEquals(0, $this->client->length('some-queue-2'));
-
         $this->assertEquals(0, $this->client->length('some-queue-3'));
     }
 
@@ -293,8 +291,7 @@ class ClientTest extends QlessTestCase
         $queue = new Queue('some-queue', $this->client);
         $queue->put('Xxx\Yyy', ['some-data'], 'job-43');
 
-        $job = $queue->pop('worker-1');
-        $job[0]->cancel();
+        $queue->pop()->cancel();
 
         $this->client->complete('job-43', 'worker-1', 'some-queue', '{}');
     }

--- a/tests/JobTest.php
+++ b/tests/JobTest.php
@@ -15,7 +15,7 @@ class JobTest extends QlessTestCase
     /**
      * @test
      * @expectedException \Qless\Exceptions\RuntimeException
-     * @expectedExceptionMessage Could not find job class Sample\TestWorkerImpl.
+     * @expectedExceptionMessage Could not find job class MyJobClass.
      */
     public function shouldThrowsExpectedExceptionWhenGetInstanceWithNonExistentClass()
     {
@@ -24,15 +24,12 @@ class JobTest extends QlessTestCase
         $this->client->config->set('heartbeat', -10);
         $this->client->config->set('grace-period', 0);
 
-        $queue->put(
-            'Sample\TestWorkerImpl',
-            ['performMethod' => 'myPerformMethod', 'payload' => 'otherData']
-        );
+        $queue->put('MyJobClass', ['performMethod' => 'myPerformMethod', 'payload' => 'otherData']);
 
-        $job1 = $queue->pop('worker-1')[0];
-        $queue->pop('worker-2');
+        $job = $queue->pop();
+        $queue->pop();
 
-        $job1->getInstance();
+        $job->getInstance();
     }
 
     /**
@@ -47,15 +44,12 @@ class JobTest extends QlessTestCase
         $this->client->config->set('heartbeat', -10);
         $this->client->config->set('grace-period', 0);
 
-        $queue->put(
-            \stdClass::class,
-            ['performMethod' => 'myPerformMethod', 'payload' => 'otherData']
-        );
+        $queue->put('stdClass', ['performMethod' => 'myPerformMethod', 'payload' => 'otherData']);
 
-        $job1 = $queue->pop('worker-1')[0];
-        $queue->pop('worker-2');
+        $job = $queue->pop();
+        $queue->pop();
 
-        $job1->getInstance();
+        $job->getInstance();
     }
 
     /**
@@ -73,15 +67,12 @@ class JobTest extends QlessTestCase
         $this->client->config->set('heartbeat', -10);
         $this->client->config->set('grace-period', 0);
 
-        $queue->put(
-            WorkerStub2::class,
-            ['performMethod' => 'myPerformMethod2', 'payload' => 'otherData']
-        );
+        $queue->put(WorkerStub2::class, ['performMethod' => 'myPerformMethod2', 'payload' => 'otherData']);
 
-        $job1 = $queue->pop('worker-1')[0];
-        $queue->pop('worker-2');
+        $job = $queue->pop();
+        $queue->pop();
 
-        $job1->getInstance();
+        $job->getInstance();
     }
 
     /** @test */
@@ -92,15 +83,12 @@ class JobTest extends QlessTestCase
         $this->client->config->set('heartbeat', -10);
         $this->client->config->set('grace-period', 0);
 
-        $queue->put(
-            WorkerStub2::class,
-            ['performMethod' => 'myPerformMethod', 'payload' => 'otherData']
-        );
+        $queue->put(WorkerStub2::class, ['performMethod' => 'myPerformMethod', 'payload' => 'otherData']);
 
-        $job1 = $queue->pop('worker-1')[0];
-        $queue->pop('worker-2');
+        $job = $queue->pop();
+        $queue->pop();
 
-        $this->assertInstanceOf(WorkerStub2::class, $job1->getInstance());
+        $this->assertInstanceOf(WorkerStub2::class, $job->getInstance());
     }
 
     /** @test */
@@ -113,10 +101,10 @@ class JobTest extends QlessTestCase
 
         $queue->put(WorkerStub2::class, ['payload' => 'otherData']);
 
-        $job1 = $queue->pop('worker-1')[0];
-        $queue->pop('worker-2');
+        $job = $queue->pop();
+        $queue->pop();
 
-        $this->assertInstanceOf(WorkerStub2::class, $job1->getInstance());
+        $this->assertInstanceOf(WorkerStub2::class, $job->getInstance());
     }
 
     /**
@@ -131,23 +119,21 @@ class JobTest extends QlessTestCase
         $this->client->config->set('heartbeat', -10);
         $this->client->config->set('grace-period', 0);
 
-        $queue->put(
-            'Sample\TestWorkerImpl',
-            ['performMethod' => 'myPerformMethod', 'payload' => 'otherData']
-        );
+        $queue->put('MyJobClass', ['performMethod' => 'myPerformMethod', 'payload' => 'otherData']);
 
-        $job1 = $queue->pop('worker-1')[0];
+        $job = $queue->pop('worker-1');
         $queue->pop('worker-2');
-        $job1->heartbeat();
+
+        $job->heartbeat();
     }
 
-    public function testCanGetCorrectTTL()
+    /** @test */
+    public function shouldGetCorrectTtl()
     {
         $queue = new Queue('testQueue', $this->client);
-        $queue->put("Sample\\TestWorkerImpl", []);
-        $job = $queue->pop('worker-1')[0];
-        $ttl = $job->ttl();
-        $this->assertGreaterThan(55, $ttl);
+        $queue->put('MyJobClass', []);
+
+        $this->assertGreaterThan(55, $queue->pop()->ttl());
     }
 
     public function testCompleteJob()
@@ -157,24 +143,18 @@ class JobTest extends QlessTestCase
         $testData = ["performMethod" => 'myPerformMethod', "payload" => "otherData"];
         $queue->put("Sample\\TestWorkerImpl", $testData);
 
-        $job1 = $queue->pop('worker-1')[0];
-        $res = $job1->complete();
-        $this->assertEquals('complete', $res);
+        $this->assertEquals('complete', $queue->pop()->complete());
     }
 
-    public function testFailJobCannotBePopped()
+    /** @test */
+    public function shouldNotPopFailedJob()
     {
         $queue = new Queue('testQueue', $this->client);
 
-        $testData = ["performMethod" => 'myPerformMethod', "payload" => "otherData"];
-        $queue->put("Sample\\TestWorkerImpl", $testData, 'jid');
+        $queue->put('MyJobClass', [], 'jid');
 
-        $job1 = $queue->pop('worker-1')[0];
-        $res = $job1->fail('account', 'failed to connect');
-        $this->assertEquals('jid', $res);
-
-        $job1 = $queue->pop('worker-1');
-        $this->assertEmpty($job1);
+        $this->assertEquals('jid', $queue->pop()->fail('account', 'failed to connect'));
+        $this->assertNull($queue->pop('worker-1'));
     }
 
     public function testRetryDoesReturnJobAndDefaultsToFiveRetries()
@@ -182,13 +162,13 @@ class JobTest extends QlessTestCase
         $queue = new Queue('testQueue', $this->client);
 
         $testData = ["performMethod" => 'myPerformMethod', "payload" => "otherData"];
-        $queue->put('Sample\TestWorkerImpl', $testData, 'jid');
+        $queue->put('MyJobClass', $testData, 'jid');
 
-        $job1 = $queue->pop('worker-1')[0];
+        $job1 = $queue->pop();
         $remaining = $job1->retry('account', 'failed to connect');
         $this->assertEquals(4, $remaining);
 
-        $job1 = $queue->pop('worker-1')[0];
+        $job1 = $queue->pop();
         $this->assertEquals('jid', $job1->getId());
     }
 
@@ -196,15 +176,10 @@ class JobTest extends QlessTestCase
     {
         $queue = new Queue('testQueue', $this->client);
 
-        $testData = ["performMethod" => 'myPerformMethod', "payload" => "otherData"];
-        $queue->put('Sample\TestWorkerImpl', $testData, 'jid', 0, 1);
+        $queue->put('MyJobClass', [], 'jid', 0, 1);
 
-        $job1 = $queue->pop('worker-1')[0];
-        $remaining = $job1->retry('account', 'failed to connect');
-        $this->assertEquals(0, $remaining);
-
-        $job1 = $queue->pop('worker-1')[0];
-        $this->assertEquals('jid', $job1->getId());
+        $this->assertZero($queue->pop()->retry('account', 'failed to connect'));
+        $this->assertEquals('jid', $queue->pop()->getId());
     }
 
     public function testRetryDoesReturnNegativeWhenNoMoreAvailable()
@@ -212,9 +187,9 @@ class JobTest extends QlessTestCase
         $queue = new Queue('testQueue', $this->client);
 
         $testData = ["performMethod" => 'myPerformMethod', "payload" => "otherData"];
-        $queue->put('Sample\TestWorkerImpl', $testData, 'jid', 0, 0);
+        $queue->put('MyJobClass', $testData, 'jid', 0, 0);
 
-        $job1 = $queue->pop('worker-1')[0];
+        $job1 = $queue->pop();
         $remaining = $job1->retry('account', 'failed to connect');
         $this->assertEquals(-1, $remaining);
     }
@@ -224,41 +199,38 @@ class JobTest extends QlessTestCase
         $queue = new Queue('testQueue', $this->client);
 
         $testData = ["performMethod" => 'myPerformMethod', "payload" => "otherData"];
-        $queue->put('Sample\TestWorkerImpl', $testData, 'jid', 0, 0);
+        $queue->put('MyJobClass', $testData, 'jid', 0, 0);
 
-        $job1 = $queue->pop('worker-1')[0];
-        $job1->retry('account', 'failed to connect');
+        $job = $queue->pop();
+        $job->retry('account', 'failed to connect');
 
-        $job1 = $queue->pop('worker-1');
-        $this->assertEmpty($job1);
+        $this->assertNull($queue->pop());
     }
 
-    public function testCancelRemovesJob()
+    /** @test */
+    public function shouldCancelRemovesJob()
     {
         $queue = new Queue('testQueue', $this->client);
 
         $data = ['performMethod' => 'myPerformMethod', 'payload' => 'otherData'];
-        $queue->put('Sample\TestWorkerImpl', $data, 'jid-1', 0, 0);
-        $queue->put('Sample\TestWorkerImpl', $data, 'jid-2', 0, 0);
 
-        $job1 = $queue->pop('worker-1')[0];
-        $res = $job1->cancel();
+        $queue->put('MyJobClass', $data, 'jid-1', 0, 0);
+        $queue->put('MyJobClass', $data, 'jid-2', 0, 0);
 
-        $this->assertEquals(['jid-1'], $res);
+        $this->assertEquals(['jid-1'], $queue->pop()->cancel());
     }
 
-    public function testCancelRemovesJobWithDependents()
+    /** @test */
+    public function shouldCancelRemovesJobWithDependents()
     {
         $queue = new Queue('testQueue', $this->client);
 
         $data = ['performMethod' => 'myPerformMethod', 'payload' => 'otherData'];
-        $queue->put('Sample\TestWorkerImpl', $data, 'jid-1', 0, 0);
-        $queue->put('Sample\TestWorkerImpl', $data, 'jid-2', 0, 0, true, 0, [], 0, [], ['jid-1']);
 
-        $job1 = $queue->pop('worker-1')[0];
-        $res = $job1->cancel(true);
+        $queue->put('MyJobClass', $data, 'jid-1', 0, 0);
+        $queue->put('MyJobClass', $data, 'jid-2', 0, 0, true, 0, [], 0, [], ['jid-1']);
 
-        $this->assertEquals(['jid-1', 'jid-2'], $res);
+        $this->assertEquals(['jid-1', 'jid-2'], $queue->pop()->cancel(true));
     }
 
     /**
@@ -269,22 +241,19 @@ class JobTest extends QlessTestCase
         $queue = new Queue('testQueue', $this->client);
 
         $data = ['performMethod' => 'myPerformMethod', 'payload' => 'otherData'];
-        $queue->put('Sample\TestWorkerImpl', $data, 'jid-1', 0, 0);
-        $queue->put('Sample\TestWorkerImpl', $data, 'jid-2', 0, 0, true, 0, [], 0, [], ['jid-1']);
 
-        $job1 = $queue->pop('worker-1')[0];
-        $job1->cancel();
+        $queue->put('MyJobClass', $data, 'jid-1', 0, 0);
+        $queue->put('MyJobClass', $data, 'jid-2', 0, 0, true, 0, [], 0, [], ['jid-1']);
+
+        $queue->pop()->cancel();
     }
 
     public function testItCanAddTagsToAJobWithNoExistingTags()
     {
         $queue = new Queue('testQueue', $this->client);
 
-        $data = ['performMethod' => 'myPerformMethod', 'payload' => 'otherData'];
-        $queue->put('Sample\TestWorkerImpl', $data, 'jid-1', 0, 0);
-
-        $job1 = $queue->pop('worker-1')[0];
-        $job1->tag('a', 'b');
+        $queue->put('MyJobClass', [], 'jid-1', 0, 0);
+        $queue->pop()->tag('a', 'b');
 
         $data = json_decode($this->client->get('jid-1'));
         $this->assertEquals(['a', 'b'], $data->tags);
@@ -294,11 +263,8 @@ class JobTest extends QlessTestCase
     {
         $queue = new Queue('testQueue', $this->client);
 
-        $data = ['performMethod' => 'myPerformMethod', 'payload' => 'otherData'];
-        $queue->put('Sample\TestWorkerImpl', $data, 'jid-1', 0, 0, true, 0, [], 0, ['1', '2']);
-
-        $job1 = $queue->pop('worker-1')[0];
-        $job1->tag('a', 'b');
+        $queue->put('MyJobClass', [], 'jid-1', 0, 0, true, 0, [], 0, ['1', '2']);
+        $queue->pop()->tag('a', 'b');
 
         $data = json_decode($this->client->get('jid-1'));
         $this->assertEquals(['1', '2', 'a', 'b'], $data->tags);
@@ -308,11 +274,8 @@ class JobTest extends QlessTestCase
     {
         $queue = new Queue('testQueue', $this->client);
 
-        $data = ['performMethod' => 'myPerformMethod', 'payload' => 'otherData'];
-        $queue->put('Sample\TestWorkerImpl', $data, 'jid-1', 0, 0, true, 0, [], 0, ['1', '2', '3']);
-
-        $job1 = $queue->pop('worker-1')[0];
-        $job1->untag('2', '3');
+        $queue->put('MyJobClass', [], 'jid-1', 0, 0, true, 0, [], 0, ['1', '2', '3']);
+        $queue->pop()->untag('2', '3');
 
         $data = json_decode($this->client->get('jid-1'));
         $this->assertEquals(['1'], $data->tags);
@@ -322,13 +285,11 @@ class JobTest extends QlessTestCase
     {
         $queue = new Queue('testQueue', $this->client);
 
-        $data = ['performMethod' => 'myPerformMethod', 'payload' => 'otherData'];
-        $queue->put('Sample\TestWorkerImpl', $data, 'jid-1', 0, 0, true, 1, [], 5, ['tag1','tag2']);
+        $queue->put('MyJobClass', [], 'jid-1', 0, 0, true, 1, [], 5, ['tag1','tag2']);
+        $queue->pop()->requeue();
 
-        $job = $queue->pop('worker-1')[0];
-        $job->requeue();
+        $job = $queue->pop();
 
-        $job = $queue->pop('worker-1')[0];
         $this->assertEquals(1, $job->getPriority());
         $this->assertEquals(['tag1','tag2'], $job->getTags());
     }
@@ -337,13 +298,10 @@ class JobTest extends QlessTestCase
     {
         $queue = new Queue('testQueue', $this->client);
 
-        $data = ['performMethod' => 'myPerformMethod', 'payload' => 'otherData'];
-        $queue->put('Sample\TestWorkerImpl', $data, 'jid-1', 0, 0, true, 1, [], 5, ['tag1','tag2']);
+        $queue->put('MyJobClass', [], 'jid-1', 0, 0, true, 1, [], 5, ['tag1','tag2']);
+        $queue->pop()->requeue(['tags' => ['nnn']]);
 
-        $job = $queue->pop('worker-1')[0];
-        $job->requeue(['tags' => ['nnn']]);
-
-        $job = $queue->pop('worker-1')[0];
+        $job = $queue->pop();
         $this->assertEquals(1, $job->getPriority());
         $this->assertEquals(['nnn'], $job->getTags());
     }
@@ -356,9 +314,9 @@ class JobTest extends QlessTestCase
         $queue = new Queue('testQueue', $this->client);
 
         $data = ['performMethod' => 'myPerformMethod', 'payload' => 'otherData'];
-        $queue->put('Sample\TestWorkerImpl', $data, 'jid-1', 0, 0, true, 1, [], 5, ['tag1','tag2']);
+        $queue->put('MyJobClass', $data, 'jid-1', 0, 0, true, 1, [], 5, ['tag1','tag2']);
 
-        $job = $queue->pop('worker-1')[0];
+        $job = $queue->pop();
         $this->client->cancel('jid-1');
         $job->requeue();
     }

--- a/tests/JobsTest.php
+++ b/tests/JobsTest.php
@@ -47,50 +47,61 @@ class JobsTest extends QlessTestCase
         $this->assertEmpty($j);
     }
 
-    public function testItReturnsCompletedJobs()
+    /** @test */
+    public function shouldReturnCompletedJobs()
     {
         $this->put('j-1');
         $this->put('j-2');
+
         $q  = new Queue('q-1', $this->client);
-        $q->pop('w-1')[0]->complete();
-        $q->pop('w-1')[0]->complete();
+
+        $q->pop()->complete();
+        $q->pop()->complete();
 
         $j = $this->client->jobs->completed();
         sort($j);
+
         $this->assertEquals(['j-1', 'j-2'], $j);
     }
 
-    public function testItReturnsFailedJobs()
+    /** @test */
+    public function shouldReturnFailedJobs()
     {
         $this->put('j-1');
         $this->put('j-2');
         $this->put('j-3');
         $this->put('j-4');
+
         $q  = new Queue('q-1', $this->client);
-        $q->pop('w-1')[0]->fail('system', 'msg');
-        $q->pop('w-1')[0]->fail('system', 'msg');
-        $q->pop('w-1')[0]->fail('system', 'msg');
-        $q->pop('w-1')[0]->fail('main', 'msg');
+
+        $q->pop()->fail('system', 'msg');
+        $q->pop()->fail('system', 'msg');
+        $q->pop()->fail('system', 'msg');
+        $q->pop()->fail('main', 'msg');
 
         $j = $this->client->jobs->failed();
+
         $this->assertEquals(3, $j['system']);
         $this->assertEquals(1, $j['main']);
     }
 
     /**
-     * @depends testItReturnsFailedJobs
+     * @test
+     * @depends shouldReturnFailedJobs
      */
-    public function testItReturnsFailedBySpecificGroup()
+    public function shouldReturnFailedBySpecificGroup()
     {
         $this->put('j-1');
         $this->put('j-2');
         $this->put('j-3');
         $this->put('j-4');
+
         $q  = new Queue('q-1', $this->client);
-        $q->pop('w-1')[0]->fail('system', 'msg');
-        $q->pop('w-1')[0]->fail('system', 'msg');
-        $q->pop('w-1')[0]->fail('system', 'msg');
-        $q->pop('w-1')[0]->fail('main', 'msg');
+
+        $q->pop()->fail('system', 'msg');
+        $q->pop()->fail('system', 'msg');
+        $q->pop()->fail('system', 'msg');
+        $q->pop()->fail('main', 'msg');
 
         $j = $this->client->jobs->failedForGroup('system');
 
@@ -103,7 +114,7 @@ class JobsTest extends QlessTestCase
         $this->put('j-2');
 
         $q  = new Queue('q-1', $this->client);
-        $q->pop('w-1');
+        $q->pop();
 
         $j = $this->client->jobs['j-1'];
         $this->assertNotNull($j);

--- a/tests/QlessTestCase.php
+++ b/tests/QlessTestCase.php
@@ -2,8 +2,10 @@
 
 namespace Qless\Tests;
 
+use PHPUnit\Framework\ExpectationFailedException;
 use PHPUnit\Framework\TestCase;
 use Qless\Client;
+use Qless\Job;
 use Qless\Tests\Support\RedisAwareTrait;
 
 /**
@@ -39,5 +41,33 @@ abstract class QlessTestCase extends TestCase
     public function tearDown(): void
     {
         $this->client->flush();
+    }
+
+    /**
+     * Asserts that a condition is zero.
+     *
+     * @param mixed  $condition
+     * @param string $message
+     *
+     * @throws ExpectationFailedException
+     * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
+     */
+    public function assertZero($condition, string $message = ''): void
+    {
+        $this->assertEquals(0, $condition, $message);
+    }
+
+    /**
+     * Asserts that a variable is instance of a Job class.
+     *
+     * @param mixed  $condition
+     * @param string $message
+     *
+     * @throws ExpectationFailedException
+     * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
+     */
+    public function assertIsJob($condition, string $message = '')
+    {
+        $this->assertInstanceOf(Job::class, $condition, $message);
     }
 }

--- a/tests/QueuePerformanceTest.php
+++ b/tests/QueuePerformanceTest.php
@@ -50,7 +50,7 @@ class QueuePerformanceTest extends QlessTestCase
         $cb(self::TEST_TIME, __METHOD__ . ' (put)');
 
         $cb = $this->getProfilerForCallback(function ($e) use ($queue) {
-            $queue->pop('worker');
+            $queue->pop();
         });
         $cb(self::TEST_TIME, __METHOD__. ' (pop)');
     }


### PR DESCRIPTION
Now calling `Qless\Queue::pop` without 2nd argument (_number of jobs to pop off of the queue_) will return `Qless\Job|null` so that there is no need to play with arrays like 
```php
$jobs = $queue->pop();
$jobs[0]->function();
```