### PR TITLE
Rework Job class to remove no longer needed getters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   If the the worker name is not passed the `Qless\Client::getWorkerName` will be used
 - Now calling `Qless\Queue::pop` without 2nd argument (number of jobs to pop off of the queue) will return
   `Qless\Job|null` so that there is no need to play with arrays like `$job[0]->function()`
+- Rework Job class to remove no longer needed getters
+- Changed signature of the `Qless\Job::requeue` from `requeue(array $opts = []): string` to
+  `requeue(?string $queue = null, array $opts = []): string` so that there is an ability to move job to a new queue
 
 ### Removed
 - Fully refactor the `Qless\Client` class and removed no longer used code

--- a/README.md
+++ b/README.md
@@ -141,6 +141,42 @@ $job->perform();
 // Perform 316eb06a-30d2-4d66-ad0d-33361306a7a1 job
 ```
 
+The job data must be serializable to JSON, and it is recommended that you use a hash for it.
+See below for a list of the supported job options.
+
+
+The argument returned by `queue->put()` is the job ID, or `jid`.
+Every Qless job has a unique `jid`, and it provides a means to interact with an existing job:
+
+```php
+// find an existing job by it's jid
+$job = $client->jobs[$jid];
+
+// query it to find out details about it:
+$job->jid;          // the job id
+$job->klass;        // the class of the job
+$job->queue;        // the queue the job is in
+$job->data;         // the data for the job
+$job->history;      // the history of what has happened to the job so far
+$job->dependencies; // the jids of other jobs that must complete before this one
+$job->dependents;   // the jids of other jobs that depend on this one
+$job->priority;     // the priority of this job
+$job->worker;       // the internal worker name (usually consumer identifier)
+$job->tags;         // array of tags for this job
+$job->expires;      // when you must either check in with a heartbeat or turn it in as completed
+$job->remaining;    // the number of retries remaining for this job
+$job->retries;      // the number of retries originally requested
+
+// there is a way to get seconds remaining before this job will timeout:
+$job->ttl();
+
+// you can also change the job in various ways:
+$job->requeue('some_other_queue'); // move it to a new queue
+$job->cancel();                    // cancel the job
+$job->tag('foo');                  // add a tag
+$job->untag('foo');                // remove a tag
+```
+
 ### Running A Worker
 
 **`@todo`**

--- a/demo/Enqueing/MyJobClass.php
+++ b/demo/Enqueing/MyJobClass.php
@@ -14,6 +14,6 @@ class MyJobClass
     public function perform(Job $job): void
     {
         // ...
-        echo 'Perform ', $job->getId(), ' job', PHP_EOL;
+        echo 'Perform ', $job->jid, ' job', PHP_EOL;
     }
 }

--- a/demo/Enqueing/test.php
+++ b/demo/Enqueing/test.php
@@ -23,3 +23,30 @@ $job = $queue->pop();
 // And we can do the work associated with it!
 $job->perform();
 // Perform 316eb06a-30d2-4d66-ad0d-33361306a7a1 job
+
+// find an existing job by it's jid
+$job = $client->jobs[$jid];
+
+// query it to find out details about it:
+$job->jid;          // the job id
+$job->klass;        // the class of the job
+$job->queue;        // the queue the job is in
+$job->data;         // the data for the job
+$job->history;      // the history of what has happened to the job so far
+$job->dependencies; // the jids of other jobs that must complete before this one
+$job->dependents;   // the jids of other jobs that depend on this one
+$job->priority;     // the priority of this job
+$job->worker;       // the internal worker name (usually consumer identifier)
+$job->tags;         // array of tags for this job
+$job->expires;      // when you must either check in with a heartbeat or turn it in as completed
+$job->remaining;    // the number of retries remaining for this job
+$job->retries;      // the number of retries originally requested
+
+// there is a way to get seconds remaining before this job will timeout:
+$job->ttl();
+
+// you can also change the job in various ways:
+$job->requeue('some_other_queue'); // move it to a new queue
+$job->cancel();                           // cancel the job
+$job->tag('foo');                  // add a tag
+$job->untag('foo');                 // remove a tag

--- a/demo/Enqueing/test.php
+++ b/demo/Enqueing/test.php
@@ -47,6 +47,6 @@ $job->ttl();
 
 // you can also change the job in various ways:
 $job->requeue('some_other_queue'); // move it to a new queue
-$job->cancel();                           // cancel the job
+$job->cancel();                    // cancel the job
 $job->tag('foo');                  // add a tag
-$job->untag('foo');                 // remove a tag
+$job->untag('foo');                // remove a tag

--- a/demo/JobHandler.php
+++ b/demo/JobHandler.php
@@ -33,10 +33,10 @@ class JobHandler implements JobHandlerInterface
      */
     public function perform(Job $job)
     {
-        $this->logger->debug('JobHandler: The job data is: ', $job->getData());
+        $this->logger->debug('JobHandler: The job data is: ', $job->data);
 
         $instance = $job->getInstance();
-        $data = $job->getData();
+        $data = $job->data;
         $performMethod = $data['performMethod'];
 
         $instance->$performMethod($job);

--- a/src/Jobs.php
+++ b/src/Jobs.php
@@ -77,7 +77,7 @@ class Jobs implements ArrayAccess
         $ret = [];
         foreach ($jobs as $data) {
             $job = new Job($this->client, $data);
-            $ret[$job->getId()] = $job;
+            $ret[$job->jid] = $job;
         }
 
         return $ret;

--- a/src/Worker.php
+++ b/src/Worker.php
@@ -151,7 +151,7 @@ class Worker
             }
 
             $this->job = $job;
-            $this->logContext['job.identifier'] = $job->getId();
+            $this->logContext['job.identifier'] = $job->jid;
 
             // fork processes
             $this->childStart();
@@ -425,7 +425,7 @@ class Worker
         $this->processType = self::PROCESS_TYPE_JOB;
         $this->clearSigHandlers();
 
-        $jid = $this->job->getId();
+        $jid = $this->job->jid;
         $this->who = 'child:' . $this->workerName;
         $this->logContext = ['type' => $this->who];
         $status = 'Processing ' . $jid . ' since ' . strftime('%F %T');
@@ -447,7 +447,7 @@ class Worker
      */
     public function childPerform(Job $job): void
     {
-        $context = ['job' => $job->getId(), 'type' => $this->who];
+        $context = ['job' => $job->jid, 'type' => $this->who];
 
         try {
             if ($this->jobPerformClass) {
@@ -533,7 +533,7 @@ class Worker
         $this->processType = self::PROCESS_TYPE_WATCHDOG;
         $this->clearSigHandlers();
 
-        $jid = $this->job->getId();
+        $jid = $this->job->jid;
         $this->who = 'watchdog:' . $this->workerName;
         $this->logContext = ['type' => $this->who];
         $status = 'watching events for ' . $jid . ' since ' . strftime('%F %T');

--- a/tests/JobTest.php
+++ b/tests/JobTest.php
@@ -169,7 +169,7 @@ class JobTest extends QlessTestCase
         $this->assertEquals(4, $remaining);
 
         $job1 = $queue->pop();
-        $this->assertEquals('jid', $job1->getId());
+        $this->assertEquals('jid', $job1->jid);
     }
 
     public function testRetryDoesRespectRetryParameterWithOneRetry()
@@ -179,7 +179,7 @@ class JobTest extends QlessTestCase
         $queue->put('MyJobClass', [], 'jid', 0, 1);
 
         $this->assertZero($queue->pop()->retry('account', 'failed to connect'));
-        $this->assertEquals('jid', $queue->pop()->getId());
+        $this->assertEquals('jid', $queue->pop()->jid);
     }
 
     public function testRetryDoesReturnNegativeWhenNoMoreAvailable()
@@ -281,7 +281,8 @@ class JobTest extends QlessTestCase
         $this->assertEquals(['1'], $data->tags);
     }
 
-    public function testRequeueJob()
+    /** @test */
+    public function shouldRequeueJob()
     {
         $queue = new Queue('testQueue', $this->client);
 
@@ -290,8 +291,8 @@ class JobTest extends QlessTestCase
 
         $job = $queue->pop();
 
-        $this->assertEquals(1, $job->getPriority());
-        $this->assertEquals(['tag1','tag2'], $job->getTags());
+        $this->assertEquals(1, $job->priority);
+        $this->assertEquals(['tag1','tag2'], $job->tags);
     }
 
     public function testRequeueJobWithNewTags()
@@ -299,11 +300,11 @@ class JobTest extends QlessTestCase
         $queue = new Queue('testQueue', $this->client);
 
         $queue->put('MyJobClass', [], 'jid-1', 0, 0, true, 1, [], 5, ['tag1','tag2']);
-        $queue->pop()->requeue(['tags' => ['nnn']]);
+        $queue->pop()->requeue(null, ['tags' => ['nnn']]);
 
         $job = $queue->pop();
-        $this->assertEquals(1, $job->getPriority());
-        $this->assertEquals(['nnn'], $job->getTags());
+        $this->assertEquals(1, $job->priority);
+        $this->assertEquals(['nnn'], $job->tags);
     }
 
     /**

--- a/tests/JobsTest.php
+++ b/tests/JobsTest.php
@@ -24,7 +24,7 @@ class JobsTest extends QlessTestCase
         $j = $this->client->jobs['j-1'];
 
         $this->assertNotNull($j);
-        $this->assertEquals('j-1', $j->getId());
+        $this->assertEquals('j-1', $j->jid);
     }
 
     public function testItReturnsExistingJobsKeyedByJobIdentifier()

--- a/tests/QueueTest.php
+++ b/tests/QueueTest.php
@@ -22,7 +22,7 @@ class QueueTest extends QlessTestCase
         $job = $queue->pop();
 
         $this->assertIsJob($job);
-        $this->assertEquals('jid', $job->getId());
+        $this->assertEquals('jid', $job->jid);
     }
 
     public function testPutWithFalseJobIDGeneratesUUID()
@@ -76,7 +76,7 @@ class QueueTest extends QlessTestCase
         }
 
         $results = array_map(function () use ($queue) {
-            return $queue->pop()->getId();
+            return $queue->pop()->jid;
         }, $jids);
 
         $this->assertEquals($jids, $results);
@@ -95,7 +95,7 @@ class QueueTest extends QlessTestCase
         }
 
         $results = array_map(function () use ($queue) {
-            return $queue->pop()->getId();
+            return $queue->pop()->jid;
         }, $jids);
 
         $this->assertEquals(array_reverse($jids), $results);
@@ -160,7 +160,7 @@ class QueueTest extends QlessTestCase
         $queue->put('Xxx\Yyy', $data, "jid-high", 0, 0, true, 1);
         $queue->put('Xxx\Yyy', $data, "jid-3");
 
-        $this->assertEquals('jid-high', $queue->pop()->getId());
+        $this->assertEquals('jid-high', $queue->pop()->jid);
     }
 
     public function testItUsesGlobalHeartbeatValueWhenNotSet()


### PR DESCRIPTION
- Rework Job class to remove no longer needed getters
- Changed signature of the `Qless\Job::requeue` from `requeue(array $opts = []): string` to `requeue(?string $queue = null, array $opts = []): string` so that there is an ability to move job to a new queue