### PR TITLE
Implement LoggerAwareInterface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - All qless exception now implements `Qless\Exceptions\ExceptionInterface`
 - Added getters and setters for those classes that used `__get` and `__set` to access their properties
+- Now the `WorkerInterface` and the `ReserverInterface` extends `Psr\Log\LoggerAwareInterface` so that
+  we can transparently share logger between worker and reserver
 
 ## [2.1.0] - 2018-10-08
 ### Added

--- a/src/Jobs/Reservers/AbstractReserver.php
+++ b/src/Jobs/Reservers/AbstractReserver.php
@@ -2,6 +2,8 @@
 
 namespace  Qless\Jobs\Reservers;
 
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
 use Qless\Exceptions\InvalidArgumentException;
 use Qless\Queues\Queue;
 
@@ -21,13 +23,29 @@ abstract class AbstractReserver implements ReserverInterface
     /** @var string|null */
     protected $worker;
 
-    /** @var string|null */
+    /**
+     * Current reserver type description.
+     *
+     * @var string|null
+     */
     protected $description;
 
+    /**
+     * Logging object that implements the PSR-3 LoggerInterface.
+     *
+     * @var LoggerInterface
+     */
+    protected $logger;
+
+    /**
+     * Current reserver type description.
+     *
+     * @var string
+     */
     protected const TYPE_DESCRIPTION = 'undefined';
 
     /**
-     * Resever constructor.
+     * Instantiate a new reserver, given a list of queues that it should be working on.
      *
      * @param Queue[]     $queues
      * @param string|null $worker
@@ -55,6 +73,7 @@ abstract class AbstractReserver implements ReserverInterface
         }
 
         $this->worker = $worker;
+        $this->logger = new NullLogger();
     }
 
     /**
@@ -91,6 +110,17 @@ abstract class AbstractReserver implements ReserverInterface
         }
 
         return $this->description;
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @param  LoggerInterface $logger
+     * @return void
+     */
+    public function setLogger(LoggerInterface $logger)
+    {
+        $this->logger = $logger;
     }
 
     protected function initializeDescription(array $queues): string

--- a/src/Jobs/Reservers/OrderedReserver.php
+++ b/src/Jobs/Reservers/OrderedReserver.php
@@ -20,10 +20,15 @@ class OrderedReserver extends AbstractReserver implements ReserverInterface
      */
     final public function reserve(): ?BaseJob
     {
+        $this->logger->debug('Attempting to reserve a job using {reserver} reserver', [
+            'reserver' => $this->getDescription(),
+        ]);
+
         foreach ($this->queues as $queue) {
             /** @var \Qless\Jobs\BaseJob|null $job */
             $job = $queue->pop($this->worker);
             if ($job !== null) {
+                $this->logger->info('Found a job on {queue}', ['queue' => (string) $queue]);
                 return $job;
             }
         }

--- a/src/Jobs/Reservers/ReserverInterface.php
+++ b/src/Jobs/Reservers/ReserverInterface.php
@@ -2,6 +2,7 @@
 
 namespace  Qless\Jobs\Reservers;
 
+use Psr\Log\LoggerAwareInterface;
 use Qless\Jobs\BaseJob;
 use Qless\Queues\Queue;
 
@@ -10,7 +11,7 @@ use Qless\Queues\Queue;
  *
  * @package Qless\Jobs\Reservers
  */
-interface ReserverInterface
+interface ReserverInterface extends LoggerAwareInterface
 {
     /**
      * Gets reserver's description.

--- a/src/Jobs/Reservers/RoundRobinReserver.php
+++ b/src/Jobs/Reservers/RoundRobinReserver.php
@@ -44,10 +44,17 @@ class RoundRobinReserver extends AbstractReserver implements ReserverInterface
      */
     final public function reserve(): ?BaseJob
     {
+        $this->logger->debug('Attempting to reserve a job using {reserver} reserver', [
+            'reserver' => $this->getDescription(),
+        ]);
+
         for ($i = 0; $i < $this->numQueues; ++$i) {
+            $queue = $this->nextQueue();
+
             /** @var \Qless\Jobs\BaseJob|null $job */
-            $job = $this->nextQueue()->pop($this->worker);
+            $job = $queue->pop($this->worker);
             if ($job !== null) {
+                $this->logger->info('Found a job on {queue}', ['queue' => (string) $queue]);
                 return $job;
             }
         }

--- a/src/Workers/AbstractWorker.php
+++ b/src/Workers/AbstractWorker.php
@@ -42,14 +42,14 @@ abstract class AbstractWorker implements WorkerInterface, EventsManagerAwareInte
     protected $reserver;
 
     /**
-     * The internal logger.
+     * Logging object that implements the PSR-3 LoggerInterface.
      *
      * @var LoggerInterface
      */
     protected $logger;
 
     /**
-     * Internal worker name.
+     * String identifying this worker.
      *
      * @var string
      */
@@ -80,7 +80,8 @@ abstract class AbstractWorker implements WorkerInterface, EventsManagerAwareInte
     private $shutdown = false;
 
     /**
-     * Worker constructor.
+     * Instantiate a new worker, given a list of queues that it should be working on.
+     *
      *
      * @param ReserverInterface $reserver
      * @param Client            $client
@@ -154,9 +155,10 @@ abstract class AbstractWorker implements WorkerInterface, EventsManagerAwareInte
      * @param  LoggerInterface $logger
      * @return void
      */
-    public function setLogger(LoggerInterface $logger): void
+    public function setLogger(LoggerInterface $logger)
     {
         $this->logger = $logger;
+        $this->reserver->setLogger($logger);
     }
 
     /**

--- a/src/Workers/ForkingWorker.php
+++ b/src/Workers/ForkingWorker.php
@@ -28,7 +28,10 @@ final class ForkingWorker extends AbstractWorker
     /** @var int */
     private $processType = self::PROCESS_TYPE_MASTER;
 
-    /** @var ?int */
+    /**
+     * Process ID of child worker processes.
+     * @var ?int
+     */
     private $childPID = null;
 
     /** @var ?int */

--- a/src/Workers/WorkerInterface.php
+++ b/src/Workers/WorkerInterface.php
@@ -2,7 +2,7 @@
 
 namespace Qless\Workers;
 
-use Psr\Log\LoggerInterface;
+use Psr\Log\LoggerAwareInterface;
 use Qless\Exceptions\RuntimeException;
 use Qless\Jobs\BaseJob;
 use Qless\Jobs\PerformAwareInterface;
@@ -12,7 +12,7 @@ use Qless\Jobs\PerformAwareInterface;
  *
  * @package Qless\Workers
  */
-interface WorkerInterface
+interface WorkerInterface extends LoggerAwareInterface
 {
     /**
      * Sets the interval for checking for new jobs.
@@ -21,14 +21,6 @@ interface WorkerInterface
      * @return void
      */
     public function setInterval(int $interval): void;
-
-    /**
-     * Sets the internal worker logger.
-     *
-     * @param  LoggerInterface $logger
-     * @return void
-     */
-    public function setLogger(LoggerInterface $logger): void;
 
     /**
      * Sets the internal worker name.


### PR DESCRIPTION
+ Now the `WorkerInterface` and the `ReserverInterface` extends `Psr\Log\LoggerAwareInterface` so that we can transparently share logger between worker and reserver