### PR TITLE
Refactor resever constructor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,18 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Added getters and setters for those classes that used `__get` and `__set` to access their properties
 - Now the `WorkerInterface` and the `ReserverInterface` extends `Psr\Log\LoggerAwareInterface` so that
   we can transparently share logger between worker and reserver
+- If the reserver was created using the specification  (regexp), it will receive an up-to-date list of queues
+  each time the `ReserverInterface::reserve()` was called
+
+### Changed
+- Changed the reserver's constructor interface so that it became possible to create an instance using:
+  - An array of the queue names
+  - A string representing the queue name
+  - A queue search specification (regexp)
+
+### Fixed
+- `Qless\Jobs\Reservers\OrderedReserver` will receive a list of queues in sorted order
+  (previously in the order in which they were added)
 
 ## [2.1.0] - 2018-10-08
 ### Added

--- a/README.md
+++ b/README.md
@@ -259,17 +259,11 @@ use Qless\Workers\ForkingWorker;
 // Create a client
 $client = new Client();
 
-/**
- * Get the queues you use.
- * @var \Qless\Queues\Queue[] $queues
- */
-$queues = array_map(function (string $name) use ($client): Queue {
-    return $client->queues[$name];
-}, ['testing', 'testing-2', 'testing-3']);
-
+// Get the queues you use.
+//
 // Create a job reserver; different reservers use different
 // strategies for which order jobs are popped off of queues
-$reserver = new OrderedReserver($queues);
+$reserver = new OrderedReserver($client->queues, ['testing', 'testing-2', 'testing-3']);
 
 $worker = new ForkingWorker($reserver, $client);
 $worker->run();
@@ -352,7 +346,7 @@ use Qless\Workers\ForkingWorker;
  */
 $jobHandler = $jobHandlerFactory->createJobHandler();
 
-$reserver = new OrderedReserver([$client->queues['my-queue']]);
+$reserver = new OrderedReserver($client->queues, 'my-queue');
 
 $worker = new ForkingWorker($reserver, $client);
 $worker->registerJobPerformHandler($jobHandler);

--- a/qlessd
+++ b/qlessd
@@ -140,31 +140,16 @@ $client = new Client(
     empty($database) ? null : (int)$database
 );
 
-$queue = $params['queue'] ?? (getenv('QUEUE') ?: null);
-if (empty($queue) == true && empty($params['queue-spec']) == true) {
-    fprintf(
-        STDERR,
-        'Set QUEUE env var containing the queue name to work.' . PHP_EOL .
-        'Otherwise you can specify a regular expression to fetch queues using "--queue-spec" option' . PHP_EOL .
-        'or use "--queue" to set queue to work.' . PHP_EOL
-    );
-
-    exit(1);
-}
-
 // Get the queues you use.
-if (empty($queue) == false) {
-    $queues = array_map(function (string $name) use ($client): Queue {
-        return $client->queues[trim($name)];
-    }, explode(',', $queue));
-} else {
-    $collection = new Collection($client);
-    $queues = $collection->fromSpec($params['queue-spec']);
-}
+$queues = $params['queue'] ?? (getenv('QUEUE') ?: null);
 
 // Create a job reserver; different reservers use different
 // strategies for which order jobs are popped off of queues
-$reserver = new OrderedReserver($queues);
+$reserver = new OrderedReserver(
+    new Collection($client),
+    empty($queue) ? null : explode(',', $queues),
+    $params['queue-spec'] ?? null
+);
 
 $worker = new ForkingWorker($reserver, $client);
 $worker->setLogger($logger);

--- a/src/Jobs/Reservers/OrderedReserver.php
+++ b/src/Jobs/Reservers/OrderedReserver.php
@@ -11,7 +11,25 @@ use Qless\Jobs\BaseJob;
  */
 class OrderedReserver extends AbstractReserver implements ReserverInterface
 {
+    /**
+     * {@inheritdoc}
+     *
+     * @var string
+     */
     const TYPE_DESCRIPTION = 'ordered';
+
+    /**
+     * {@inheritdoc}
+     *
+     * @return void
+     */
+    public function beforeWork(): void
+    {
+        parent::beforeWork();
+
+        sort($this->queues);
+        $this->resetDescription();
+    }
 
     /**
      * {@inheritdoc}
@@ -20,6 +38,8 @@ class OrderedReserver extends AbstractReserver implements ReserverInterface
      */
     final public function reserve(): ?BaseJob
     {
+        $this->beforeWork();
+
         $this->logger->debug('Attempting to reserve a job using {reserver} reserver', [
             'reserver' => $this->getDescription(),
         ]);

--- a/src/Jobs/Reservers/RoundRobinReserver.php
+++ b/src/Jobs/Reservers/RoundRobinReserver.php
@@ -4,6 +4,7 @@ namespace  Qless\Jobs\Reservers;
 
 use Qless\Exceptions\InvalidArgumentException;
 use Qless\Jobs\BaseJob;
+use Qless\Queues\Collection;
 use Qless\Queues\Queue;
 
 /**
@@ -19,19 +20,30 @@ class RoundRobinReserver extends AbstractReserver implements ReserverInterface
     /** @var int  */
     private $lastIndex = 0;
 
-    const TYPE_DESCRIPTION = 'round robin';
-
     /**
      * {@inheritdoc}
      *
-     * @param Queue[]     $queues
-     * @param string|null $worker
+     * @var string
+     */
+    const TYPE_DESCRIPTION = 'round robin';
+
+    /**
+     * Instantiate a new reserver, given a list of queues that it should be working on.
+     *
+     * @param  Collection  $collection
+     * @param  array|null  $queues
+     * @param  string|null $spec
+     * @param  string|null $worker
      *
      * @throws InvalidArgumentException
      */
-    public function __construct(array $queues, ?string $worker = null)
-    {
-        parent::__construct($queues, $worker);
+    public function __construct(
+        Collection $collection,
+        ?array $queues = null,
+        ?string $spec = null,
+        ?string $worker = null
+    ) {
+        parent::__construct($collection, $queues, $spec, $worker);
 
         $this->numQueues = count($this->queues);
         $this->lastIndex = $this->numQueues - 1;
@@ -44,6 +56,8 @@ class RoundRobinReserver extends AbstractReserver implements ReserverInterface
      */
     final public function reserve(): ?BaseJob
     {
+        $this->beforeWork();
+
         $this->logger->debug('Attempting to reserve a job using {reserver} reserver', [
             'reserver' => $this->getDescription(),
         ]);

--- a/src/Jobs/Reservers/ShuffledRoundRobinReserver.php
+++ b/src/Jobs/Reservers/ShuffledRoundRobinReserver.php
@@ -9,6 +9,11 @@ namespace  Qless\Jobs\Reservers;
  */
 class ShuffledRoundRobinReserver extends RoundRobinReserver
 {
+    /**
+     * {@inheritdoc}
+     *
+     * @var string
+     */
     const TYPE_DESCRIPTION = 'shuffled round robin';
 
     /**
@@ -18,6 +23,8 @@ class ShuffledRoundRobinReserver extends RoundRobinReserver
      */
     public function beforeWork(): void
     {
+        parent::beforeWork();
+
         shuffle($this->queues);
         $this->resetDescription();
     }

--- a/src/Workers/ForkingWorker.php
+++ b/src/Workers/ForkingWorker.php
@@ -88,13 +88,10 @@ final class ForkingWorker extends AbstractWorker
         $this->who = 'master:' . $this->name;
         $this->logContext = ['type' => $this->who, 'job.identifier' => null];
         $this->logger->info('{type}: worker started', $this->logContext);
-        $this->logger->info(
-            '{type}: monitoring the following queues (in order): {queues}',
-            ['type' => $this->who, 'queues' => implode(', ', $this->reserver->getQueues())]
-        );
+
+        $this->reserver->beforeWork();
 
         $didWork = false;
-        $this->reserver->beforeWork();
 
         while (true) {
             // Don't wait on any processes if we're already in shutdown mode.

--- a/tests/Events/CustomJobPerformHandlerTest.php
+++ b/tests/Events/CustomJobPerformHandlerTest.php
@@ -19,10 +19,12 @@ class CustomJobPerformHandlerTest extends QlessTestCase
     /** @test */
     public function shouldSubscribeOnEvents()
     {
-        $queue = new Queue('test-queue', $this->client);
-        $jid = $queue->put(JobHandler::class, []);
+        $jid = (new Queue('test-queue', $this->client))->put(JobHandler::class, []);
 
-        $worker = new PerformClassAwareWorker(new OrderedReserver([$queue]), $this->client);
+        $worker = new PerformClassAwareWorker(
+            new OrderedReserver($this->client->queues, ['test-queue']),
+            $this->client
+        );
 
         $eventsDrivenJobHandler = new EventsDrivenJobHandler();
         $worker->registerJobPerformHandler($eventsDrivenJobHandler);

--- a/tests/Jobs/Reservers/ShuffledRoundRobinReserverTest.php
+++ b/tests/Jobs/Reservers/ShuffledRoundRobinReserverTest.php
@@ -12,13 +12,14 @@ use Qless\Queues\Queue;
  */
 class ShuffledRoundRobinReserverTest extends RoundRobinReserverTest
 {
-    /** @test */
-    public function shouldReturnNulForNoQueues()
+    /**
+     * @test
+     * @expectedException \Qless\Exceptions\InvalidArgumentException
+     * @expectedExceptionMessage A queues list or a specification to reserve queues are required.
+     */
+    public function shouldThrowExceptionForNoQueuesAndSpec()
     {
-        $reserver = new ShuffledRoundRobinReserver([]);
-
-        $this->assertEquals([], $reserver->getQueues());
-        $this->assertNull($reserver->reserve());
+        new ShuffledRoundRobinReserver($this->client->queues, []);
     }
 
     /** @test */
@@ -29,7 +30,7 @@ class ShuffledRoundRobinReserverTest extends RoundRobinReserverTest
 
         $stack = [$queue1, $queue2];
 
-        $reserver = new ShuffledRoundRobinReserver($stack);
+        $reserver = new ShuffledRoundRobinReserver($this->client->queues, ['queue-1', 'queue-2']);
 
         $this->assertEquals($stack, $reserver->getQueues());
     }
@@ -37,10 +38,7 @@ class ShuffledRoundRobinReserverTest extends RoundRobinReserverTest
     /** @test */
     public function shouldGetDescription()
     {
-        $queue1 = new Queue('queue-1', $this->client);
-        $queue2 = new Queue('queue-2', $this->client);
-
-        $reserver = new ShuffledRoundRobinReserver([$queue1, $queue2]);
+        $reserver = new ShuffledRoundRobinReserver($this->client->queues, ['queue-1', 'queue-2']);
 
         $this->assertEquals('queue-1, queue-2 (shuffled round robin)', $reserver->getDescription());
     }
@@ -49,13 +47,8 @@ class ShuffledRoundRobinReserverTest extends RoundRobinReserverTest
     public function shouldShuffleQueuesBeforeWork()
     {
         $reserver = new ShuffledRoundRobinReserver(
-            [
-                new Queue('queue-1', $this->client),
-                new Queue('queue-2', $this->client),
-                new Queue('queue-3', $this->client),
-                new Queue('queue-4', $this->client),
-                new Queue('queue-5', $this->client),
-            ]
+            $this->client->queues,
+            ['queue-1', 'queue-2', 'queue-3', 'queue-4', 'queue-5']
         );
 
         $reserver->beforework();


### PR DESCRIPTION
### Added

- If the reserver was created using the specification  (regexp), it will receive an up-to-date list of queues each time the `ReserverInterface::reserve()` was called

### Changed
- Changed the reserver's constructor interface so that it became possible to create an instance using:
  - An array of the queue names
  - A string representing the queue name
  - A queue search specification (regexp)

### Fixed
- `Qless\Jobs\Reservers\OrderedReserver` will receive a list of queues in sorted order
  (previously in the order in which they were added)