### PR TITLE
Replace gethostname -> php_uname

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+## Fixed
+- `gethostname()` doesn't work properly (or at least always) on Amazon's EC2 thus it replaced by `php_uname('n')`
 
 ## [2.2.1] - 2018-10-09
 ### Fixed

--- a/src/Client.php
+++ b/src/Client.php
@@ -81,7 +81,7 @@ class Client implements EventsManagerAwareInterface
      */
     public function __construct(string $server, ?int $database = null)
     {
-        $this->workerName = gethostname() . '-' . getmypid();
+        $this->workerName = php_uname('n') . '-' . getmypid();
 
         $this->redis = new Redis($server, $database);
         $this->redis->connect();


### PR DESCRIPTION
Hello!

* Type: bug fix
* Link to issue: https://github.com/chrisboulton/php-resque/pull/226

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)?
- [x] I have checked that another pull request for this purpose does not exist.
- [ ] I wrote some tests for this PR.

Small description of change:

The `gethostname()` function doesn't work properly (or at least always) on Amazon's EC2 thus it replaced by `php_uname('n')`.

Thanks
