### PR TITLE
Add failure getter to a job

### DIFF
--- a/src/Jobs/AbstractJob.php
+++ b/src/Jobs/AbstractJob.php
@@ -182,6 +182,14 @@ abstract class AbstractJob implements EventsManagerAwareInterface
     }
 
     /**
+     * @return array
+     */
+    public function getFailure(): array
+    {
+        return $this->rawData['failure'] ?? [];
+    }
+
+    /**
      * Add the specified tags to this job.
      *
      * @param  string ...$tags A list of tags to to add to this job.


### PR DESCRIPTION
Hello!

* Type: bug fix

Small description of change:
As a developer I need to read the error message when a job fails. AbstractJob already has this kind of info but it's impossible to get access.

Thanks
