### PR TITLE
Get completed jobs by queue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 ### Added
 - Added possibility to get jobs in worker (all jobs or by time filter).
-- Added possibility to get jobs in status waiting
+- Added possibility to get jobs in status waiting.
+- Added possibility to get jobs in status completed by queue.
 ### Changed
 - Check current job status before change it in Redis
+### Fixed
+- Fixed bug on parameters order in 'job' method.
 
 ## [3.5.0] - 2019-02-08
 ### Added
@@ -181,7 +184,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
  - Initial stable release
 
-[Unreleased]: https://github.com/pdffiller/qless-php/compare/v3.4.0...HEAD
+[Unreleased]: https://github.com/pdffiller/qless-php/compare/v3.5.0...HEAD
+[3.5.0]: https://github.com/pdffiller/qless-php/compare/v3.4.0...v3.5.0
 [3.4.0]: https://github.com/pdffiller/qless-php/compare/v3.3.0...v3.4.0
 [3.3.0]: https://github.com/pdffiller/qless-php/compare/v3.2.0...v3.3.0
 [3.2.0]: https://github.com/pdffiller/qless-php/compare/v3.1.0...v3.2.0

--- a/adm/docker/docker-compose.yml
+++ b/adm/docker/docker-compose.yml
@@ -3,7 +3,7 @@ version: '3'
 services:
 
   redis:
-    image: redis:3-alpine
+    image: redis:5-alpine
     container_name: qless-redis
     ports:
       - "6380:6379"

--- a/src/Client.php
+++ b/src/Client.php
@@ -28,7 +28,7 @@ use Predis\Client as Redis;
  * @method array cancel(string $jid)
  * @method int unrecur(string $jid)
  * @method bool|string fail(string $jid, string $worker, string $group, string $message, ?string $data = null)
- * @method string[] jobs(string $state, int $offset = 0, int $count = 25)
+ * @method string[] jobs(string $state, string $queue, int $offset = 0, int $count = 25)
  * @method null|string get(string $jid)
  * @method string multiget(string[] $jid)
  * @method string complete(string $jid, string $workerName, string $queueName, string $data, ...$args)

--- a/src/Jobs/Collection.php
+++ b/src/Jobs/Collection.php
@@ -39,7 +39,7 @@ class Collection implements ArrayAccess
      */
     public function completed(int $offset = 0, int $count = 25)
     {
-        return $this->client->jobs('complete', $offset, $count);
+        return $this->client->jobs('complete', null, $offset, $count);
     }
 
     /**

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -421,4 +421,23 @@ WRK;
 
         $this->assertEquals($jobId, array_pop($jobIds));
     }
+
+    /** @test */
+    public function shouldGetCompletedList()
+    {
+        $queueName = uniqid('completed_test_', false);
+        $jobId = uniqid('job-', false);
+
+        $queue = new Queue($queueName, $this->client);
+
+        $queue->put('Xxx\Yyy', ['test' => 'some-data'], $jobId);
+
+        $job = $queue->popByJid($jobId);
+
+        $job->complete();
+
+        $jobIds = $this->client->jobs('complete', $queueName);
+
+        $this->assertEquals($jobId, array_pop($jobIds));
+    }
 }


### PR DESCRIPTION
#70 

* Type: bug fix | new feature

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)?
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I wrote some tests for this PR.

Fixed bug on parameters order in 'job' method.
Added possibility to get jobs in status completed by queue.