### PR TITLE
Pop by id only jobs in status wait

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Check current job status before change it in Redis
 ### Fixed
 - Fixed bug on parameters order in 'job' method.
+- Removed possibility to get a job by id twice
 
 ## [3.5.0] - 2019-02-08
 ### Added

--- a/src/Queues/Queue.php
+++ b/src/Queues/Queue.php
@@ -157,6 +157,10 @@ class Queue implements EventsManagerAwareInterface
         $data = json_decode($this->client->popByJid($this->name, $jid, $workerName), true);
         $jobData = array_reduce($data, 'array_merge', []); //unwrap nested array
 
+        if (isset($jobData['jid']) === false) {
+            return null;
+        }
+
         if ($jobData['jid'] === $jid) {
             $job = new BaseJob($this->client, $jobData);
             $job->setEventsManager($this->getEventsManager());

--- a/tests/Jobs/BaseJobTest.php
+++ b/tests/Jobs/BaseJobTest.php
@@ -589,6 +589,21 @@ class BaseJobTest extends QlessTestCase
         $this->assertFalse($job->getFailed());
     }
 
+    public function testPopByIdOnce()
+    {
+        $queue = $this->client->queues['test-queue'];
+
+        $jid = $queue->put(JobHandler::class, []);
+
+        $job = $queue->popByJid($jid);
+
+        $this->assertIsJob($job);
+
+        $job2 = $queue->popByJid($jid);
+
+        $this->assertNull($job2);
+    }
+
     public function testJobCantChangeFailToComplete()
     {
         $queue = $this->client->queues['test-queue'];

--- a/tests/Topics/TopicTest.php
+++ b/tests/Topics/TopicTest.php
@@ -25,8 +25,16 @@ class TopicTest extends QlessTestCase
 
         $queuesCollection = new Collection($this->client);
 
-        $this->assertEquals(['test-queue-2', 'test-queue-1'], $queuesCollection->fromSubscriptions('big.green.apples'));
-        $this->assertEquals(['test-queue-2', 'test-queue-1'], $queuesCollection->fromSubscriptions('big.red.apples'));
+        $queuesExpected = ['test-queue-1', 'test-queue-2'];
+
+        $queuesGreenApples = $queuesCollection->fromSubscriptions('big.green.apples');
+        sort($queuesGreenApples);
+
+        $queuesRedApples = $queuesCollection->fromSubscriptions('big.red.apples');
+        sort($queuesRedApples);
+
+        $this->assertEquals($queuesExpected, $queuesGreenApples);
+        $this->assertEquals($queuesExpected, $queuesRedApples);
         $this->assertEquals([], $queuesCollection->fromSubscriptions('*.*.oranges'));
 
         $queues[1]->unsubscribe('big.*.*');


### PR DESCRIPTION
Hello!

* Type: bug fix

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)?
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I wrote some tests for this PR.

Small description of change:
Removed possibility to get a job by id twice

Thanks
