### PR TITLE
Added possibility to get a list of tracked jobs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+- Added getter of tracked jobs list
 
 ## [3.7.0] - 2019-04-19
 ### Added

--- a/src/Client.php
+++ b/src/Client.php
@@ -34,6 +34,7 @@ use Predis\Client as Redis;
  * @method string complete(string $jid, string $workerName, string $queueName, string $data, ...$args)
  * @method void timeout(string $jid)
  * @method string failed(string|bool $group = false, int $start = 0, int $limit = 25)
+ * @method string tracked()
  * @method string[] tag(string $op, $tags)
  * @method string stats(string $queueName, int $date)
  * @method void pause(string $queueName, ...$args)

--- a/src/Jobs/Collection.php
+++ b/src/Jobs/Collection.php
@@ -140,7 +140,7 @@ class Collection implements ArrayAccess
      */
     public function tracked(): array
     {
-        $tracked = $this->client->call('tracked') ?? [];
+        $tracked = $this->client->call('tracked') ?? '[]';
 
         return json_decode($tracked, true);
     }

--- a/src/Jobs/Collection.php
+++ b/src/Jobs/Collection.php
@@ -134,6 +134,18 @@ class Collection implements ArrayAccess
     }
 
     /**
+     * Fetches a list of tracked jobs.
+     *
+     * @return array
+     */
+    public function tracked(): array
+    {
+        $tracked = $this->client->call('tracked') ?? [];
+
+        return json_decode($tracked, true);
+    }
+
+    /**
      * Reads jobs in a worker.
      *
      * @param string $worker

--- a/src/qless-core/qless.lua
+++ b/src/qless-core/qless.lua
@@ -2109,6 +2109,11 @@ QlessAPI.workerJobs = function(now, worker, minScore)
   return cjson.encode(QlessWorker.jobs(worker, minScore))
 end
 
+QlessAPI.tracked = function (now)
+  local tracked = redis.call('zrange', 'ql:tracked', 0, -1)
+  return cjson.encode(tracked)
+end
+
 QlessAPI.track = function(now, command, jid)
   return cjson.encode(Qless.track(now, command, jid))
 end

--- a/tests/Jobs/CollectionTest.php
+++ b/tests/Jobs/CollectionTest.php
@@ -31,6 +31,24 @@ class CollectionTest extends QlessTestCase
     }
 
     /** @test */
+    public function shouldGetTrackedJobs()
+    {
+        $this->client->queues['foo']->put('Foo', [], 'jid-1');
+        $this->client->queues['foo']->put('Bar', [], 'jid-2');
+        $this->assertCount(0, $this->client->jobs->tracked());
+
+        $this->client->jobs['jid-1']->track();
+        $this->assertCount(1, $this->client->jobs->tracked());
+        $this->client->jobs['jid-2']->track();
+        $this->assertCount(2, $this->client->jobs->tracked());
+
+        $this->client->jobs['jid-1']->untrack();
+        $this->assertCount(1, $this->client->jobs->tracked());
+        $this->client->jobs['jid-2']->untrack();
+        $this->assertCount(0, $this->client->jobs->tracked());
+    }
+
+    /** @test */
     public function shouldReturnNullForInvalidJobID()
     {
         $this->assertNull($this->client->jobs['xxx']);


### PR DESCRIPTION
Hello!

* Type: new feature

Small description of change:
Now we can  track() a job
However we need to read all tracked jobs.

Thanks
