### PR TITLE
PubSub Manager, aka Qless-native Events

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ phpcs.xml
 infection.json
 infection-log.txt
 infection-log.json
+/tests/pubsubmanager-jobactions.log

--- a/.travis.yml
+++ b/.travis.yml
@@ -66,6 +66,7 @@ after_success:
 after_failure:
   - $(phpenv which php) -v
   - for m in `$(phpenv which php) -m | grep -e 'json\|pcntl\|posix\|sockets\|pcre'`; do php --ri $m; done
+  - tail -n +1 tests/*.log
 
 notifications:
   email: false

--- a/README.md
+++ b/README.md
@@ -549,6 +549,46 @@ $job->tag('howdy', 'hello');
 $job->untag('foo', 'bar');
 ```
 
+#### Notifications
+Tracked jobs emit events on specific pubsub channels as things happen to them. Whether it's getting popped off of a queue, completed by a worker, etc.
+
+An example of this is:
+
+```php
+/**
+ * @var \Qless\Client $client
+ * @var \Qless\PubSub\Manager $events
+ */
+$events = $client->events;
+$events->on(
+    Qless\PubSub\Manager::EVENT_COMPLETED,
+    function (string $jid) {
+        echo "{$jid} completed";
+    }
+);
+
+$events->listen();
+```
+
+Those familiar with redis pubsub will note that a redis connection can only be used for pubsub-y commands once listening. For this reason, invoking `Client->events` actually creates a second connection so that `Client` can still be used as it normally would be:
+
+```php
+/**
+ * @var \Qless\Client $client
+ * @var \Qless\PubSub\Manager $events
+ */
+$events = $client->events;
+$events->on(
+    Qless\PubSub\Manager::EVENT_FAILED,
+    function (string $jid) use ($client) {
+        echo "{$jid} failed in {$client->jobs[$jid]->queue}";
+    }
+);
+
+$events->listen();
+```
+
+
 #### Event System
 
 Qless also has a basic event system that can be used by your application to customize how some of the qless internals

--- a/README.md
+++ b/README.md
@@ -588,6 +588,8 @@ $events->on(
 $events->listen();
 ```
 
+The possible event types match those defined by [Qless-core](ttps://github.com/seomoz/qless-core) and are defined as constants on the `\Qless\PubSub\Manager` class: `EVENT_CANCELED`, `EVENT_COMPLETED`, `EVENT_FAILED`, `EVENT_POPPED`, `EVENT_STALLED`, `EVENT_PUT`, `EVENT_TRACK`, `EVENT_UNTRACK`.  
+
 
 #### Event System
 

--- a/src/Client.php
+++ b/src/Client.php
@@ -221,7 +221,8 @@ class Client implements EventsManagerAwareInterface
         return $this->lua;
     }
 
-    public function getEvents(): PubSubManager {
+    public function getEvents(): PubSubManager
+    {
         return $this->events;
     }
 

--- a/src/Client.php
+++ b/src/Client.php
@@ -8,6 +8,7 @@ use Qless\Queues\Collection as QueuesCollection;
 use Qless\Subscribers\WatchdogSubscriber;
 use Qless\Support\PropertyAccessor;
 use Qless\Workers\Collection as WorkersCollection;
+use Qless\PubSub\Manager as PubSubManager;
 use Predis\Client as Redis;
 
 /**
@@ -50,6 +51,7 @@ use Predis\Client as Redis;
  * @property-read QueuesCollection $queues
  * @property-read Config $config
  * @property-read LuaScript $lua
+ * @property-read PubSubManager $events
  */
 class Client implements EventsManagerAwareInterface
 {
@@ -77,6 +79,11 @@ class Client implements EventsManagerAwareInterface
     private $workerName;
 
     /**
+     * @var PubSubManager
+     */
+    private $events;
+
+    /**
      * Client constructor.
      *
      * @param  mixed $parameters Connection parameters for one or more servers.
@@ -99,6 +106,7 @@ class Client implements EventsManagerAwareInterface
         $this->jobs = new JobsCollection($this);
         $this->workers = new WorkersCollection($this);
         $this->queues = new QueuesCollection($this);
+        $this->events = new PubSubManager($this, new Redis($parameters, $options));
     }
 
     /**
@@ -211,6 +219,10 @@ class Client implements EventsManagerAwareInterface
     public function getLua(): LuaScript
     {
         return $this->lua;
+    }
+
+    public function getEvents(): PubSubManager {
+        return $this->events;
     }
 
     /**

--- a/src/Client.php
+++ b/src/Client.php
@@ -106,7 +106,7 @@ class Client implements EventsManagerAwareInterface
         $this->jobs = new JobsCollection($this);
         $this->workers = new WorkersCollection($this);
         $this->queues = new QueuesCollection($this);
-        $this->events = new PubSubManager($this, new Redis($parameters, $options));
+        $this->events = new PubSubManager(new Redis($parameters, $options));
     }
 
     /**

--- a/src/PubSub/Manager.php
+++ b/src/PubSub/Manager.php
@@ -1,0 +1,182 @@
+<?php
+
+namespace Qless\PubSub;
+
+use Predis\PubSub\Consumer;
+use Psr\Log\LoggerAwareInterface;
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
+use Qless\Client;
+use Qless\Exceptions\InvalidArgumentException;
+use Predis\Client as Redis;
+use Ramsey\Uuid\Exception\InvalidUuidStringException;
+use Ramsey\Uuid\Uuid;
+
+/**
+ * Qless\PubSub\Manager
+ *
+ * Listen for qless-core notifications via PubSub
+ *
+ * @package Qless\PubSub
+ */
+final class Manager implements LoggerAwareInterface
+{
+
+    public const EVENT_CANCELED = 'canceled';
+    public const EVENT_COMPLETED = 'completed';
+    public const EVENT_FAILED = 'failed';
+    public const EVENT_POPPED = 'popped';
+    public const EVENT_STALLED = 'stalled';
+    public const EVENT_PUT = 'put';
+    public const EVENT_TRACK = 'track';
+    public const EVENT_UNTRACK = 'untrack';
+
+    /**
+     * @var Redis
+     */
+    public $redis;
+
+    /**
+     * @var Client
+     */
+    protected $client;
+
+    /** @var LoggerInterface */
+    private $logger;
+
+    /**
+     * @var \Closure[][]
+     */
+    protected $callbacks = [
+        self::EVENT_CANCELED => [],
+        self::EVENT_COMPLETED => [],
+        self::EVENT_FAILED => [],
+        self::EVENT_POPPED => [],
+        self::EVENT_STALLED => [],
+        self::EVENT_PUT => [],
+        self::EVENT_TRACK => [],
+        self::EVENT_UNTRACK => []
+    ];
+
+    public function __construct(Client $client, Redis $redis)
+    {
+        $this->client = $client;
+        $this->redis = $redis;
+        $this->logger = new NullLogger();
+    }
+
+    /**
+     * Convert an event name to a Qless PUBSUB channel name
+     *
+     * @param string $event
+     *
+     * @return string
+     */
+    protected static function channelName(string $event): string
+    {
+        return "ql:{$event}";
+    }
+
+    /**
+     * Convert a Qless PUBSUB channel name to an event name
+     *
+     * @param string $channel
+     *
+     * @return string
+     */
+    protected static function eventName(string $channel): string
+    {
+        return \preg_replace('/^ql:/', '', $channel);
+    }
+
+    /**
+     * Listen for Events of the given type.
+     *
+     * @param string $event The event type. Should be one of the PubSub\Manager::EVENT_* constants.
+     * @param callable $callback The callback to invoke when the event occurs.
+     *
+     * @return $this
+     */
+    public function on(string $event, callable $callback): self
+    {
+        if (! \array_key_exists($event, $this->callbacks)) {
+            throw new InvalidArgumentException('event must be a known event type');
+        }
+
+        $this->callbacks[$event][] = \Closure::fromCallable($callback);
+
+        return $this;
+    }
+
+    /**
+     * Listen for Events, and invoke registered callbacks.
+     */
+    public function listen(): void
+    {
+        $channels = \array_map([static::class, 'channelName'], \array_keys($this->callbacks));
+
+        $this->redis->connect();
+
+        /** @var Consumer $pubSub */
+        $pubSub = $this->redis->pubSubLoop();
+        $pubSub->subscribe(...$channels);
+        /** @var \stdClass $message */
+        foreach ($pubSub as $message) {
+            $this->handleMessage($message);
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @param  LoggerInterface $logger
+     * @return void
+     */
+    public function setLogger(LoggerInterface $logger)
+    {
+        $this->logger = $logger;
+    }
+
+
+    /**
+     * Handle a received message
+     *
+     * @param \stdClass $message
+     */
+    protected function handleMessage(\stdClass $message): void
+    {
+        if ($message->kind !== 'message' || empty($message->payload)) {
+            return;
+        }
+
+        $jid = $message->payload;
+        if (empty($jid)) {
+            return;
+        }
+
+        try {
+            Uuid::fromString($jid);
+        } catch (InvalidUuidStringException $exception) {
+            $this->logger->warning('Invalid JID received: ' . $jid, \compact('message'));
+            return;
+        }
+
+        $event = static::eventName($message->channel);
+
+        if (! array_key_exists($event, $this->callbacks)) {
+            $this->logger->warning('Unknown event type received: ' . $event, \compact('message'));
+            return;
+        }
+
+        foreach ($this->callbacks[$event] as $closure) {
+            try {
+                $closure($jid);
+            } catch (\Throwable $exception) {
+                $this->logger->error(
+                    'Error while running callback: ' . $exception->getMessage(),
+                    \compact('jid', 'event', 'exception')
+                );
+            }
+        }
+    }
+}

--- a/src/PubSub/Manager.php
+++ b/src/PubSub/Manager.php
@@ -36,7 +36,7 @@ final class Manager implements LoggerAwareInterface
      */
     public $redis;
 
-    /** @var Consumer */
+    /** @var Consumer|null */
     protected $pubSubConsumer;
 
     /** @var LoggerInterface */

--- a/tests/PubSub/DummyPubSubJob.php
+++ b/tests/PubSub/DummyPubSubJob.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Qless\Tests\PubSub;
+
+use Qless\Jobs\BaseJob;
+use Qless\PubSub\Manager;
+
+class DummyPubSubJob
+{
+    public function perform(BaseJob $job): void
+    {
+
+
+        $type = $job->data['type'] ?? null;
+
+        switch ($type) {
+            case Manager::EVENT_CANCELED:
+            case Manager::EVENT_POPPED:
+            case Manager::EVENT_TRACK:
+                $job->cancel();
+                break;
+            case Manager::EVENT_COMPLETED:
+                $job->complete();
+                break;
+            case Manager::EVENT_FAILED:
+                $job->fail('test', 'triggering deliberate fail');
+                break;
+            case Manager::EVENT_STALLED:
+                if ($job->retries === $job->remaining) {
+                    \sleep($job->ttl() + 1);
+                }
+                break;
+            case Manager::EVENT_UNTRACK:
+                $job->untrack();
+                break;
+
+            case Manager::EVENT_PUT:
+                $job->requeue(ManagerTest::QUEUE_NAME . '2');
+                break;
+
+            default:
+                \fwrite(STDERR, 'Invalid job type provided: ' . var_export($type, true) . PHP_EOL);
+        }
+    }
+}

--- a/tests/PubSub/ManagerTest.php
+++ b/tests/PubSub/ManagerTest.php
@@ -156,7 +156,7 @@ class ManagerTest extends QlessTestCase
         $jid = $queue->put(DummyPubSubJob::class, compact('type'));
 
         $this->runBackgroundTask(
-            $_SERVER['_'],
+            '/usr/bin/php',
             [__DIR__ . '/../pubsubmanager-jobactions.php', $type, $jid],
             __DIR__ . '/../pubsubmanager-jobactions.log'
         );

--- a/tests/PubSub/ManagerTest.php
+++ b/tests/PubSub/ManagerTest.php
@@ -156,7 +156,7 @@ class ManagerTest extends QlessTestCase
         $jid = $queue->put(DummyPubSubJob::class, compact('type'));
 
         $this->runBackgroundTask(
-            '/usr/bin/php',
+            'php',
             [__DIR__ . '/../pubsubmanager-jobactions.php', $type, $jid],
             __DIR__ . '/../pubsubmanager-jobactions.log'
         );

--- a/tests/PubSub/ManagerTest.php
+++ b/tests/PubSub/ManagerTest.php
@@ -1,0 +1,182 @@
+<?php
+
+namespace Qless\Tests\PubSub;
+
+use Qless\Exceptions\InvalidArgumentException;
+use Qless\Jobs\BaseJob;
+use Qless\Jobs\Reservers\DefaultReserver;
+use Qless\PubSub\Manager;
+use Qless\Tests\QlessTestCase;
+use Qless\Tests\Stubs\SimpleTestWorker;
+
+/**
+ * Qless\Tests\PubSub\ManagerTest
+ *
+ * @package Qless\Tests
+ */
+class ManagerTest extends QlessTestCase
+{
+
+    public const QUEUE_NAME = 'pubsub-manager-test';
+
+
+    public const EVENT_TYPES = [
+        Manager::EVENT_CANCELED,
+        Manager::EVENT_COMPLETED,
+        Manager::EVENT_FAILED,
+        Manager::EVENT_POPPED,
+        Manager::EVENT_STALLED,
+        Manager::EVENT_PUT,
+        Manager::EVENT_TRACK,
+        Manager::EVENT_UNTRACK
+    ];
+
+    /**
+     * @var array
+     */
+    protected $pipes;
+
+    /**
+     * @var false|resource
+     */
+    protected $process;
+
+    /** @test */
+    public function shouldNotAcceptOtherEvents(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        $this->client->events->on('foo', static function (BaseJob $job) {
+        });
+    }
+
+    /** @test */
+    public function shouldReceiveCanceledEvent(): void
+    {
+        $this->shouldReceivedExpectedMessageType(Manager::EVENT_CANCELED);
+    }
+
+    /** @test */
+    public function shouldReceiveCompletedEvent(): void
+    {
+        $this->shouldReceivedExpectedMessageType(Manager::EVENT_COMPLETED);
+    }
+
+    /** @test */
+    public function shouldReceiveFailedEvent(): void
+    {
+        $this->shouldReceivedExpectedMessageType(Manager::EVENT_FAILED);
+    }
+
+    /** @test */
+    public function shouldReceivePoppedEvent(): void
+    {
+        $this->shouldReceivedExpectedMessageType(Manager::EVENT_POPPED);
+    }
+
+    /** @test */
+    public function shouldReceiveStalledEvent(): void
+    {
+        $this->shouldReceivedExpectedMessageType(Manager::EVENT_STALLED);
+    }
+
+    /** @test */
+    public function shouldReceivePutEvent(): void
+    {
+        $this->shouldReceivedExpectedMessageType(Manager::EVENT_PUT);
+    }
+
+    /** @test */
+    public function shouldReceiveTrackEvent(): void
+    {
+        $this->shouldReceivedExpectedMessageType(Manager::EVENT_TRACK);
+    }
+
+    /** @test */
+    public function shouldReceiveUntrackEvent(): void
+    {
+        $this->shouldReceivedExpectedMessageType(Manager::EVENT_UNTRACK);
+    }
+
+    protected function runBackgroundTask(string $command, array $arguments = [], ?string $errorLog = null): void
+    {
+
+        $this->process = proc_open(
+            escapeshellcmd($command) . ' ' . implode(' ', array_map('escapeshellarg', $arguments)),
+            [
+                ['pipe', 'r'],
+                ['pipe', 'w'],
+                $errorLog ? ['file', $errorLog, 'a'] : ['pipe', 'w']
+            ],
+            $this->pipes,
+            getcwd()
+        );
+        stream_set_blocking($this->pipes[1], false);
+        if (! $errorLog) {
+            stream_set_blocking($this->pipes[2], false);
+        }
+    }
+
+    protected function getBackgroundStdOut(): string
+    {
+        if (is_resource($this->pipes[1]) && get_resource_type($this->pipes[1]) !== 'Unknown') {
+            stream_set_blocking($this->pipes[1], true);
+        }
+
+        return stream_get_contents($this->pipes[1]);
+    }
+
+    protected function stopBackgroundTask(): void
+    {
+        foreach ($this->pipes as $type => &$pipe) {
+            if (! is_resource($pipe)) {
+                continue;
+            }
+            fclose($pipe);
+        }
+        unset($pipe);
+
+        proc_terminate($this->process);
+        $this->process = null;
+        $this->pipes = null;
+    }
+
+    protected function shouldReceivedExpectedMessageType(string $type): void
+    {
+        $client = $this->client;
+
+        $jobLimit = 1;
+        if ($type === Manager::EVENT_STALLED) {
+            $jobLimit = 2;
+            $client->config->set('heartbeat', 5);
+        }
+
+        $queue = $client->queues[self::QUEUE_NAME];
+
+        $jid = $queue->put(DummyPubSubJob::class, compact('type'));
+
+        $this->runBackgroundTask(
+            $_SERVER['_'],
+            [__DIR__ . '/../pubsubmanager-jobactions.php', $type, $jid],
+            __DIR__ . '/../pubsubmanager-jobactions.log'
+        );
+
+        sleep(2);
+
+        $client->jobs[$jid]->track();
+
+        $expectedMessage = sprintf('%s: %s', $type, $jid);
+
+        $worker = new SimpleTestWorker(
+            new DefaultReserver($client->queues, [self::QUEUE_NAME]),
+            $client
+        );
+        $worker->setMaximumNumberJobs($jobLimit);
+        $worker->run();
+        $client->workers->remove($worker->getName());
+        $messagesReceived = explode(PHP_EOL, $this->getBackgroundStdOut());
+        $this->stopBackgroundTask();
+
+        $this->assertContains($expectedMessage, $messagesReceived, 'Expected events of type ' . $type);
+    }
+}

--- a/tests/Stubs/SimpleTestWorker.php
+++ b/tests/Stubs/SimpleTestWorker.php
@@ -1,0 +1,120 @@
+<?php
+
+namespace Qless\Tests\Stubs;
+
+use Qless\Events\User\Job as JobEvent;
+use Qless\Workers\AbstractWorker;
+
+class SimpleTestWorker extends AbstractWorker {
+
+    /**
+     * @var int
+     */
+    private $maximumNumberOfJobs;
+
+    /**
+     * Time limit execution
+     *
+     * @var int
+     */
+    private $timeLimitInSeconds;
+
+    /**
+     * @var int
+     */
+    private $endTime;
+
+    /**
+     * @var int
+     */
+    private $numberExecutedJobs = 0;
+
+    /**
+     * @param int $seconds
+     */
+    public function setTimeLimit(int $seconds): void
+    {
+        $this->timeLimitInSeconds = $seconds;
+    }
+
+    /**
+     * @param int $number
+     */
+    public function setMaximumNumberJobs(int $number): void
+    {
+        $this->maximumNumberOfJobs = $number;
+    }
+
+    public function perform(): void
+    {
+        $this->endTime = $this->timeLimitInSeconds ? $this->timeLimitInSeconds + microtime(true) : null;
+
+        while (true) {
+            $this->stopWhenTimeLimitIsReached();
+
+            // Don't wait on any processes if we're already in shutdown mode.
+            if ($this->isShuttingDown() == true) {
+                break;
+            }
+
+            $job = $this->reserve();
+            if ($job === null) {
+                if ($this->interval === 0) {
+                    break;
+                }
+                usleep($this->interval * 1000000);
+                continue;
+            }
+
+            try {
+                $job->perform();
+            } catch (\Throwable $e) {
+                $loggerContext['stack'] = $e->getMessage();
+                $this->logger->critical('{type}: job {job} has failed {stack}', $loggerContext);
+
+                $job->fail(
+                    'system:fatal',
+                    sprintf('%s: %s in %s on line %d', get_class($e), $e->getMessage(), $e->getFile(), $e->getLine())
+                );
+            }
+            $this->stopWhenJobCountIsExceeded();
+        }
+    }
+
+    /**
+     * Stop when job count is exceeded
+     *
+     * @return void
+     */
+    private function stopWhenJobCountIsExceeded(): void
+    {
+        if ($this->isShuttingDown() || !($this->maximumNumberOfJobs > 0)) {
+            return;
+        }
+        if (++$this->numberExecutedJobs >= $this->maximumNumberOfJobs) {
+            $this->logger->info('Worker stopped due to maximum count of {count} exceeded', [
+                'count' => $this->maximumNumberOfJobs
+            ]);
+            $this->shutdown();
+        }
+    }
+
+    /**
+     * Stop when time limit is reached
+     *
+     * @return void
+     */
+    private function stopWhenTimeLimitIsReached(): void
+    {
+        if ($this->isShuttingDown() || $this->timeLimitInSeconds === null) {
+            return;
+        }
+        if ($this->endTime < microtime(true)) {
+            $this->logger->info('Worker stopped due to time limit of {timeLimit}s reached', [
+                'timeLimit' => $this->timeLimitInSeconds
+            ]);
+            $this->shutdown();
+        }
+    }
+
+}

--- a/tests/Stubs/SimpleTestWorker.php
+++ b/tests/Stubs/SimpleTestWorker.php
@@ -5,7 +5,8 @@ namespace Qless\Tests\Stubs;
 use Qless\Events\User\Job as JobEvent;
 use Qless\Workers\AbstractWorker;
 
-class SimpleTestWorker extends AbstractWorker {
+class SimpleTestWorker extends AbstractWorker
+{
 
     /**
      * @var int
@@ -116,5 +117,4 @@ class SimpleTestWorker extends AbstractWorker {
             $this->shutdown();
         }
     }
-
 }

--- a/tests/pubsubmanager-jobactions.php
+++ b/tests/pubsubmanager-jobactions.php
@@ -1,0 +1,49 @@
+<?php
+
+use Predis\Connection\ConnectionException;
+use Qless\Client;
+
+require_once __DIR__ . '/bootstrap.php';
+
+$client = new Client(
+    [
+        'host' => REDIS_HOST,
+        'port' => REDIS_PORT,
+    ]
+);
+
+$pubSubManager = $client->events;
+
+$pid = posix_getpid();
+array_shift($_SERVER['argv']);
+array_shift($_SERVER['argv']);
+$eventType = array_shift($_SERVER['argv']);
+$expectedJID = array_shift($_SERVER['argv']);
+
+\fprintf(STDERR, 'Waiting for Event type "%s" for jid "%s" in process %d'. PHP_EOL, $eventType, $expectedJID, $pid);
+
+$pubSubManager->on(
+    $eventType,
+    static function ($jid) use ($eventType, $expectedJID, $pid, $pubSubManager) {
+        \printf('%s: %s' . PHP_EOL, $eventType, $jid);
+        \fprintf(STDERR, 'Got Event type "%s" for jid "%s" in process %d'. PHP_EOL, $eventType, $jid, $pid);
+        if ($jid === $expectedJID) {
+            $pubSubManager->stopListening();
+            exit(0);
+        }
+    }
+);
+
+while (true) {
+    try {
+        $pubSubManager->listen();
+    } catch (ConnectionException $exception) {
+        \fwrite(STDERR, $exception->getMessage() . PHP_EOL);
+        \fwrite(STDERR, 'Reconnecting to Redis' . PHP_EOL);
+        $client->reconnect();
+        continue;
+    } catch (\Throwable $exception) {
+        \fwrite(STDERR, $exception->getMessage() . PHP_EOL);
+        exit(1);
+    }
+}

--- a/tests/pubsubmanager-jobactions.php
+++ b/tests/pubsubmanager-jobactions.php
@@ -16,7 +16,6 @@ $pubSubManager = $client->events;
 
 $pid = posix_getpid();
 array_shift($_SERVER['argv']);
-array_shift($_SERVER['argv']);
 $eventType = array_shift($_SERVER['argv']);
 $expectedJID = array_shift($_SERVER['argv']);
 


### PR DESCRIPTION
* Type: new feature
* Link to issue: #100 

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/pdffiller/qless-php/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I wrote some tests for this PR.


This roughly follows the Python (and to a lesser extent Ruby) API, where `Client` exposes an `events` property which has `on(name, callback)` and `listen()` methods.

I noticed the existing Watchdog PubSub consumer does a clone/disconnect/reconnect, but that method does not seem to reliably give a new connection (to allow the callback to use `Client` for other calls).

The current implementation also doesn't offer the priority functionality of the existing callback based "Events" system - I thought it more important to keep parity with the upstream feature.

I had to make a guess about naming too, it's not clear to me whether this class should be in the root `Qless` namespace, or even if you have some better name than `PubSub Manager` - EventsManager is taken and I assume you wouldn't just drop the old implementation.

I've done some very minimal tests of this and it works as expected across processes. It'd be great to get some feedback in terms of naming/structure/etc and I can refine it from there.
