### PR TITLE
Tracked jobs autoclear

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [3.10.1]
+### Fixed
+ - Clear old data of removed tracked jobs 
+
 ## [3.10.0]
 ### Added
  - Added getting queues by priority range
@@ -227,7 +231,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
  - Initial stable release
 
-[Unreleased]: https://github.com/pdffiller/qless-php/compare/v3.10.0...HEAD
+[Unreleased]: https://github.com/pdffiller/qless-php/compare/v3.10.1...HEAD
+[3.10.1]: https://github.com/pdffiller/qless-php/compare/v3.10.0...v3.10.1
 [3.10.0]: https://github.com/pdffiller/qless-php/compare/v3.9.1...v3.10.0
 [3.9.1]: https://github.com/pdffiller/qless-php/compare/v3.9.0...v3.9.1
 [3.9.0]: https://github.com/pdffiller/qless-php/compare/v3.8.3...v3.9.0

--- a/src/qless-core/qless.lua
+++ b/src/qless-core/qless.lua
@@ -1029,6 +1029,8 @@ function Qless.queue(name)
 
       redis.call('zremrangebyrank', queue:prefix('completed'), 0, (-1-count))
 
+      redis.call('zremrangebyscore', 'ql:tracked', 0, now - time)
+
       return redis.call('zadd',
         queue:prefix('completed'), now, jid)
     end, score = function(jid)


### PR DESCRIPTION
Hello!

* Type: bug fix

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)?
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I wrote some tests for this PR.

Records about tracked jobs don't delete. This code deletes data of old tracked jobs.
Thanks
