### PR TITLE
Fix PHPUnit dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -41,7 +41,7 @@
     },
     "require-dev": {
         "phpstan/phpstan": "0.10.*",
-        "phpunit/phpunit": ">=5.3 <8.0",
+        "phpunit/phpunit": ">=7.5 <8.0",
         "squizlabs/php_codesniffer": "3.*"
     },
     "suggest": {


### PR DESCRIPTION
Closes pdffiller/qless-php#106

Hello!

* Type: bug fix | new feature | code quality | documentation
* Link to issue: pdffiller/qless-php#106

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)?
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I wrote some tests for this PR.

Small description of change:

Fixes composer dependency to provide `isArray` assertion.

Thanks
