### PR TITLE
Force check worker variable type

### DIFF
--- a/src/qless-core/qless.lua
+++ b/src/qless-core/qless.lua
@@ -1711,7 +1711,7 @@ function QlessQueue:invalidate_lock_jid(now, jid)
   local worker, failure = unpack(
           redis.call('hmget', QlessJob.ns .. jid, 'worker', 'failure'))
 
-  if worker == nil then
+  if type(worker) ~= 'string' then
     worker = '';
   end
 
@@ -1768,7 +1768,7 @@ function QlessQueue:invalidate_locks(now, count)
     local worker, failure = unpack(
       redis.call('hmget', QlessJob.ns .. jid, 'worker', 'failure'))
 
-    if worker == nil then
+    if type(worker) ~= 'string' then
       worker = '';
     end
 


### PR DESCRIPTION
Hello!

* Type: bug fix

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)?
- [x] I have checked that another pull request for this purpose does not exist.
- [ ] I wrote some tests for this PR.

Small description of change:
Last night we had a problem with the qless.
There was a lot of errors in the logs.
```
ERR Error running script (call to f_511fb327c0239f8f160ab6505c28ecfd2acb4bc4): @user_script:1716: user_script:1716: attempt to concatenate local 'worker' (a boolean value)
```
Queue stopped.

Why the variable worker turned out to have a Boolean value - I do not know. But we added code like in PR to the hot server and everything was decided



Thanks
