### PR TITLE
[CORE-2926] Register syncCompleteEvent only if needed

### DIFF
--- a/src/Queues/Queue.php
+++ b/src/Queues/Queue.php
@@ -43,7 +43,10 @@ class Queue implements EventsManagerAwareInterface
         $this->name   = $name;
 
         $this->setEventsManager($this->client->getEventsManager());
-        $this->registerSyncCompleteEvent();
+
+        if ($this->client->config->get('sync-enabled')) {
+            $this->registerSyncCompleteEvent();
+        }
     }
 
     /**

--- a/tests/Jobs/BaseJobTest.php
+++ b/tests/Jobs/BaseJobTest.php
@@ -600,21 +600,22 @@ class BaseJobTest extends QlessTestCase
 
     public function testJobCanCompleteSync()
     {
-        $queue = $this->client->queues['test-queue'];
-
-        $queue->put(JobHandler::class, []);
-
         $this->client->config->set('sync-enabled', true);
-
+        $queue = $this->client->queues['test-queue-sync-enabled'];
         $jid = $queue->put(JobHandler::class, []);
-
         $job = $this->client->jobs[$jid];
-
-        $this->client->config->clear('sync-enabled');
 
         $this->assertIsJob($job);
         $this->assertArrayHasKey('stack', $job->data->toArray());
         $this->assertFalse($job->getFailed());
+
+        $this->client->config->clear('sync-enabled');
+        $queue = $this->client->queues['test-queue-sync-disabled'];
+        $jid = $queue->put(JobHandler::class, []);
+        $job = $this->client->jobs[$jid];
+
+        $this->assertIsJob($job);
+        $this->assertArrayNotHasKey('stack', $job->data->toArray());
     }
 
     public function testPopByIdOnce()


### PR DESCRIPTION
Hello!

* Type: bug fix
* Link to issue: https://pdffiller.atlassian.net/browse/CORE-2926

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)?
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I wrote some tests for this PR.

Small description of change: Every time object is instantiated, we add one more Listener to the same eventsManager, it produces memory and CPU leak, because amount of listeners is growing linearly.

Thanks
