### PR TITLE
Add support for forgetting a queue.

### DIFF
--- a/src/Queues/Collection.php
+++ b/src/Queues/Collection.php
@@ -4,6 +4,7 @@ namespace Qless\Queues;
 
 use ArrayAccess;
 use Qless\Client;
+use Qless\Exceptions\QlessException;
 use Qless\Exceptions\UnsupportedFeatureException;
 use Qless\Support\PropertyAccessor;
 
@@ -136,10 +137,10 @@ class Collection implements ArrayAccess
     /**
      * {@inheritdoc}
      *
-     * @throws UnsupportedFeatureException
+     * @throws QlessException If the queue is not empty.
      */
     public function offsetUnset($offset)
     {
-        throw new UnsupportedFeatureException('Deleting a queue is not supported using Queues collection.');
+        $this[$offset]->forget();
     }
 }

--- a/src/Queues/Queue.php
+++ b/src/Queues/Queue.php
@@ -382,6 +382,23 @@ class Queue implements EventsManagerAwareInterface
     }
 
     /**
+     * Forget this queue, removing it from the backing store
+     *
+     * @param bool $force Force the queue to be removed, ignoring any jobs held in the queue.
+     *
+     * @return void
+     * @throws QlessException If the queue is not empty.
+     */
+    public function forget(bool $force = false): void
+    {
+        if (!$force && $this->length() > 0) {
+            throw new QlessException('Queue is not empty');
+        }
+
+        $this->client->call('queue.forget', $this->name);
+    }
+
+    /**
      * Pauses this queue so it will not process any more Jobs.
      *
      * @return void


### PR DESCRIPTION
Closes #111

Hello!

* Type: new feature
* Link to issue: #111

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)?
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I wrote some tests for this PR.

Small description of change:

Adds support for 'forgetting' Queues.

Thanks
