### PR TITLE
Cleanup unit tests

### DIFF
--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -22,13 +22,17 @@ class ClientTest extends QlessTestCase
 {
     use RedisAwareTrait;
 
-    /** @test */
+    /**
+     * @test
+     */
     public function shouldGetEmptyWorkersList(): void
     {
         self::assertEquals('{}', $this->client->call('workers'));
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function shouldGetAWorkersList(): void
     {
         $this->client->pop('test-queue', 'w1', 1);
@@ -62,7 +66,9 @@ WRK;
         );
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function shouldCreateASubscriber(): void
     {
         self::assertInstanceOf(WatchdogSubscriber::class, $this->client->createSubscriber([]));
@@ -93,8 +99,6 @@ WRK;
 
     /**
      * @test
-     *
-     *
      */
     public function shouldThrowExceptionWhenGetInaccessibleProperty(): void
     {
@@ -155,7 +159,9 @@ WRK;
         );
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function shouldReturnEmptyStringWhenJobDoesNotExist(): void
     {
         self::assertEquals('{}', $this->client->pop('non-existent-queue', 'worker-1', 1));
@@ -219,7 +225,9 @@ WRK;
         ];
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function shouldRetrieveStats(): void
     {
         $queue = new Queue('some-queue', $this->client);
@@ -247,7 +255,9 @@ WRK;
         self::assertCount(4, $stats['run']);
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function shouldPauseTheQueue(): void
     {
         $queue = new Queue('some-queue', $this->client);
@@ -262,7 +272,9 @@ WRK;
         self::assertFalse($queue->isPaused());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function shouldGetJob(): void
     {
         $queue = new Queue('some-queue', $this->client);
@@ -276,7 +288,9 @@ WRK;
         self::assertNull($this->client->get('job-43'));
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function shouldCorrectDetermineLength(): void
     {
         $queue = new Queue('some-queue-2', $this->client);
@@ -294,8 +308,6 @@ WRK;
 
     /**
      * @test
-     *
-     *
      */
     public function shouldThrowExpectedExceptionOnCompleteRunningJob(): void
     {
@@ -309,8 +321,6 @@ WRK;
 
     /**
      * @test
-     *
-     *
      */
     public function shouldThrowExpectedExceptionOnCompleteNonExistingJob(): void
     {
@@ -324,7 +334,9 @@ WRK;
         $this->client->complete('job-43', 'worker-1', 'some-queue', '{}');
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function shouldCompleteJob(): void
     {
         $queue = new Queue('some-queue', $this->client);
@@ -338,7 +350,9 @@ WRK;
         );
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function shouldReturnAListOfQueues(): void
     {
         $this->client->flush();
@@ -410,8 +424,6 @@ WRK;
 
     /**
      * @test
-     *
-     *
      */
     public function shouldThrowExceptionWhenTimeoutFail(): void
     {
@@ -420,7 +432,9 @@ WRK;
         $this->client->timeout('foo');
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function shouldGetWaitingList(): void
     {
         $queueName = uniqid('waiting_test_', false);
@@ -432,7 +446,9 @@ WRK;
         self::assertEquals($jobId, array_pop($jobIds));
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function shouldGetCompletedList(): void
     {
         $queueName = uniqid('completed_test_', false);

--- a/tests/ConfigTest.php
+++ b/tests/ConfigTest.php
@@ -10,45 +10,45 @@ namespace Qless\Tests;
 class ConfigTest extends QlessTestCase
 {
     /** @test */
-    public function shouldGetDefaultHeartbeat()
+    public function shouldGetDefaultHeartbeat(): void
     {
-        $this->assertEquals(60, $this->client->config->get('heartbeat'));
+        self::assertEquals(60, $this->client->config->get('heartbeat'));
     }
 
     /** @test */
-    public function shouldSetConfigValue()
+    public function shouldSetConfigValue(): void
     {
         $key = md5(uniqid(microtime(true), true));
         $value = hash('sha1', uniqid(microtime(true), true));
 
         $this->client->config->set($key, $value);
-        $this->assertEquals($value, $this->client->config->get($key));
+        self::assertEquals($value, $this->client->config->get($key));
     }
 
     /** @test */
-    public function shouldGetDefaultValue()
+    public function shouldGetDefaultValue(): void
     {
-        $this->assertEquals(null, $this->client->config->get('foo.bar.baz'));
-        $this->assertEquals('xyz', $this->client->config->get('foo.bar.baz', 'xyz'));
+        self::assertEquals(null, $this->client->config->get('foo.bar.baz'));
+        self::assertEquals('xyz', $this->client->config->get('foo.bar.baz', 'xyz'));
     }
 
     /** @test */
-    public function shouldGetDefaultGracePeriod()
+    public function shouldGetDefaultGracePeriod(): void
     {
         $val = $this->client->config->get('grace-period');
-        $this->assertEquals(10, $val);
+        self::assertEquals(10, $val);
     }
 
     /** @test */
-    public function shouldSetHeartbeat()
+    public function shouldSetHeartbeat(): void
     {
         $this->client->config->set('heartbeat', 10);
         $val = $this->client->config->get('heartbeat');
-        $this->assertEquals(10, $val);
+        self::assertEquals(10, $val);
     }
 
     /** @test */
-    public function shouldClearTheConfigValue()
+    public function shouldClearTheConfigValue(): void
     {
         $key = md5(uniqid(microtime(true), true));
         $value = hash('sha1', uniqid(microtime(true), true));
@@ -56,6 +56,6 @@ class ConfigTest extends QlessTestCase
         $this->client->config->set($key, $value);
         $this->client->config->clear($key);
 
-        $this->assertNull($this->client->config->get($key));
+        self::assertNull($this->client->config->get($key));
     }
 }

--- a/tests/ConfigTest.php
+++ b/tests/ConfigTest.php
@@ -9,13 +9,17 @@ namespace Qless\Tests;
  */
 class ConfigTest extends QlessTestCase
 {
-    /** @test */
+    /**
+     * @test
+     */
     public function shouldGetDefaultHeartbeat(): void
     {
         self::assertEquals(60, $this->client->config->get('heartbeat'));
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function shouldSetConfigValue(): void
     {
         $key = md5(uniqid(microtime(true), true));
@@ -25,21 +29,27 @@ class ConfigTest extends QlessTestCase
         self::assertEquals($value, $this->client->config->get($key));
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function shouldGetDefaultValue(): void
     {
         self::assertEquals(null, $this->client->config->get('foo.bar.baz'));
         self::assertEquals('xyz', $this->client->config->get('foo.bar.baz', 'xyz'));
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function shouldGetDefaultGracePeriod(): void
     {
         $val = $this->client->config->get('grace-period');
         self::assertEquals(10, $val);
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function shouldSetHeartbeat(): void
     {
         $this->client->config->set('heartbeat', 10);
@@ -47,7 +57,9 @@ class ConfigTest extends QlessTestCase
         self::assertEquals(10, $val);
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function shouldClearTheConfigValue(): void
     {
         $key = md5(uniqid(microtime(true), true));

--- a/tests/Events/CustomJobPerformHandlerTest.php
+++ b/tests/Events/CustomJobPerformHandlerTest.php
@@ -16,7 +16,9 @@ use Qless\Tests\Stubs\PerformClassAwareWorker;
  */
 class CustomJobPerformHandlerTest extends QlessTestCase
 {
-    /** @test */
+    /**
+     * @test
+     */
     public function shouldSubscribeOnEvents(): void
     {
         $jid = (new Queue('test-queue', $this->client))->put(JobHandler::class, []);

--- a/tests/Events/CustomJobPerformHandlerTest.php
+++ b/tests/Events/CustomJobPerformHandlerTest.php
@@ -17,7 +17,7 @@ use Qless\Tests\Stubs\PerformClassAwareWorker;
 class CustomJobPerformHandlerTest extends QlessTestCase
 {
     /** @test */
-    public function shouldSubscribeOnEvents()
+    public function shouldSubscribeOnEvents(): void
     {
         $jid = (new Queue('test-queue', $this->client))->put(JobHandler::class, []);
 
@@ -36,6 +36,6 @@ class CustomJobPerformHandlerTest extends QlessTestCase
             "{$jid}:job:afterPerform"
         ];
 
-        $this->assertEquals($expected, $_SERVER['caller']['stack']);
+        self::assertEquals($expected, $_SERVER['caller']['stack']);
     }
 }

--- a/tests/Events/JobEventsTest.php
+++ b/tests/Events/JobEventsTest.php
@@ -31,7 +31,9 @@ class JobEventsTest extends QlessTestCase
         $this->status = new stdClass();
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function shouldSubscribeToAroundPerformEvents(): void
     {
         $this->putJob();
@@ -70,7 +72,9 @@ class JobEventsTest extends QlessTestCase
         self::assertEquals($expected, $job->data->toArray());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function shouldAppendJobDataViaEventSubscriber(): void
     {
         $this->subscribeToQueueEvents();

--- a/tests/Events/JobEventsTest.php
+++ b/tests/Events/JobEventsTest.php
@@ -8,6 +8,7 @@ use Qless\Tests\QlessTestCase;
 use Qless\Tests\Stubs\JobHandler;
 use Qless\Tests\Stubs\JobSubscriber;
 use Qless\Events\User\Queue\BeforeEnqueue;
+use stdClass;
 
 /**
  * Qless\Tests\Events\JobEventsTest
@@ -27,23 +28,23 @@ class JobEventsTest extends QlessTestCase
     {
         parent::setUp();
 
-        $this->status = new \stdClass();
+        $this->status = new stdClass();
     }
 
     /** @test */
-    public function shouldSubscribeToAroundPerformEvents()
+    public function shouldSubscribeToAroundPerformEvents(): void
     {
         $this->putJob();
         $this->subscribeToJobEvents();
 
         $job = $this->popJob();
 
-        $this->assertFalse(isset($this->status->triggered));
-        $this->assertEquals([], $job->data->toArray());
+        self::assertFalse(isset($this->status->triggered));
+        self::assertEquals([], $job->data->toArray());
 
         $job->perform();
 
-        $this->assertTrue(isset($this->status->triggered));
+        self::assertTrue(isset($this->status->triggered));
 
         $expected = [
             [
@@ -56,7 +57,7 @@ class JobEventsTest extends QlessTestCase
             ]
         ];
 
-        $this->assertEquals($expected, $this->status->triggered);
+        self::assertEquals($expected, $this->status->triggered);
 
         $expected = [
             'stack' => [
@@ -66,18 +67,18 @@ class JobEventsTest extends QlessTestCase
             ],
         ];
 
-        $this->assertEquals($expected, $job->data->toArray());
+        self::assertEquals($expected, $job->data->toArray());
     }
 
     /** @test */
-    public function shouldAppendJobDataViaEventSubscriber()
+    public function shouldAppendJobDataViaEventSubscriber(): void
     {
         $this->subscribeToQueueEvents();
         $this->putJob(['payload' => 'data']);
 
         $job = $this->popJob();
 
-        $this->assertEquals(
+        self::assertEquals(
             [
                 'payload' => 'data',
                 'metadata' => [
@@ -95,7 +96,7 @@ class JobEventsTest extends QlessTestCase
         return $queue->pop();
     }
 
-    private function subscribeToQueueEvents()
+    private function subscribeToQueueEvents(): void
     {
         $this->client
             ->getEventsManager()
@@ -107,7 +108,7 @@ class JobEventsTest extends QlessTestCase
             });
     }
 
-    private function subscribeToJobEvents()
+    private function subscribeToJobEvents(): void
     {
         $this->client->getEventsManager()->attach('job', new JobSubscriber($this->status));
     }

--- a/tests/Events/WatchdogSubscriberTest.php
+++ b/tests/Events/WatchdogSubscriberTest.php
@@ -16,7 +16,9 @@ class WatchdogSubscriberTest extends QlessTestCase
 {
     use RedisAwareTrait;
 
-    /** @test */
+    /**
+     * @test
+     */
     public function shouldReceiveExpectedMessages(): void
     {
         $system = $this->createMock(SystemFacade::class);

--- a/tests/Events/WatchdogSubscriberTest.php
+++ b/tests/Events/WatchdogSubscriberTest.php
@@ -17,12 +17,12 @@ class WatchdogSubscriberTest extends QlessTestCase
     use RedisAwareTrait;
 
     /** @test */
-    public function shouldReceiveExpectedMessages()
+    public function shouldReceiveExpectedMessages(): void
     {
         $system = $this->createMock(SystemFacade::class);
 
         $system
-            ->expects($this->atLeast(1))
+            ->expects(self::atLeast(1))
             ->method('posixKill')
             ->with(1, SIGKILL)
             ->willReturn(true);
@@ -37,6 +37,6 @@ class WatchdogSubscriberTest extends QlessTestCase
         exec(escapeshellcmd("php '{$publisher}'") . " > {$publisher}.log 2>&1 &");
 
         $listener->watchdog('jid-1', 'test-worker', 1);
-        $this->assertTrue(true);
+        self::assertTrue(true);
     }
 }

--- a/tests/Exceptions/ErrorFormatterTest.php
+++ b/tests/Exceptions/ErrorFormatterTest.php
@@ -12,29 +12,31 @@ use Qless\Tests\QlessTestCase;
  */
 class ErrorFormatterTest extends QlessTestCase
 {
+
     /**
      * @test
      * @dataProvider errorConstantsProvider
+     *
      * @param mixed $value
      * @param string $expected
      */
-    public function shouldReturnConstantName($value, $expected)
+    public function shouldReturnConstantName($value, string $expected): void
     {
         $handler = new ErrorFormatter();
 
-        $this->assertEquals($expected, $handler->constant($value));
+        self::assertEquals($expected, $handler->constant($value));
     }
 
     /** @test */
-    public function shouldReturnNullOnNonExistentConstant()
+    public function shouldReturnNullOnNonExistentConstant(): void
     {
         $handler = new ErrorFormatter();
 
-        $this->assertNull($handler->constant(7));
-        $this->assertNull($handler->constant('error'));
+        self::assertNull($handler->constant(7));
+        self::assertNull($handler->constant('error'));
     }
 
-    public function errorConstantsProvider()
+    public function errorConstantsProvider(): array
     {
         return [
             [E_ERROR, 'E_ERROR'],

--- a/tests/Exceptions/ErrorFormatterTest.php
+++ b/tests/Exceptions/ErrorFormatterTest.php
@@ -27,7 +27,9 @@ class ErrorFormatterTest extends QlessTestCase
         self::assertEquals($expected, $handler->constant($value));
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function shouldReturnNullOnNonExistentConstant(): void
     {
         $handler = new ErrorFormatter();

--- a/tests/Jobs/BaseJobTest.php
+++ b/tests/Jobs/BaseJobTest.php
@@ -22,8 +22,6 @@ class BaseJobTest extends QlessTestCase
 {
     /**
      * @test
-     *
-     *
      */
     public function shouldThrowExceptionWhenSettingUnknownProperty(): void
     {
@@ -38,7 +36,9 @@ class BaseJobTest extends QlessTestCase
         $job->foo = 'bar';
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function shouldChangeJobPriority(): void
     {
         $queue = $this->client->queues['test-queue'];
@@ -55,7 +55,9 @@ class BaseJobTest extends QlessTestCase
         self::assertEquals(18, $job->priority);
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function shouldChangeFailedFlag(): void
     {
         $queue = $this->client->queues['test-queue'];
@@ -74,7 +76,9 @@ class BaseJobTest extends QlessTestCase
         self::assertEquals(true, $job->failed);
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function shouldRequeueJob(): void
     {
         $queue = $this->client->queues['test-queue'];
@@ -90,8 +94,6 @@ class BaseJobTest extends QlessTestCase
 
     /**
      * @test
-     *
-     *
      */
     public function shouldThrowsExpectedExceptionWhenGetInstanceWithNonExistentClass(): void
     {
@@ -112,8 +114,6 @@ class BaseJobTest extends QlessTestCase
 
     /**
      * @test
-     *
-     *
      */
     public function shouldThrowsExpectedExceptionWhenGetInstanceWithNonExistentPerformMethod(): void
     {
@@ -156,7 +156,9 @@ class BaseJobTest extends QlessTestCase
         $job->getInstance();
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function shouldGetWorkerInstance(): void
     {
         $queue = $this->client->queues['test-queue'];
@@ -172,7 +174,9 @@ class BaseJobTest extends QlessTestCase
         self::assertInstanceOf(JobHandler::class, $job->getInstance());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function shouldGetWorkerInstanceWithDefaultPerformMethod(): void
     {
         $queue = $this->client->queues['test-queue'];
@@ -210,8 +214,6 @@ class BaseJobTest extends QlessTestCase
 
     /**
      * @test
-     *
-     *
      */
     public function shouldThrowLostLockExceptionWhenHeartbeatFail(): void
     {
@@ -223,7 +225,9 @@ class BaseJobTest extends QlessTestCase
         $this->client->jobs['jid']->heartbeat();
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function shouldProvideAccessToHeartbeat(): void
     {
         $this->client->config->set('heartbeat', 10);
@@ -238,7 +242,9 @@ class BaseJobTest extends QlessTestCase
         self::assertTrue($job->ttl() > $before);
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function shouldStartTrackingJob(): void
     {
         $this->client->queues['foo']->put('Foo', [], 'jid');
@@ -251,7 +257,9 @@ class BaseJobTest extends QlessTestCase
         self::assertFalse($this->client->jobs['jid']->tracked);
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function shouldRemoveOldTrackingJob(): void
     {
         $lifetime = 1;
@@ -281,8 +289,6 @@ class BaseJobTest extends QlessTestCase
 
     /**
      * @test
-     *
-     *
      */
     public function shouldThrowExceptionWhenTimeoutFail(): void
     {
@@ -292,7 +298,9 @@ class BaseJobTest extends QlessTestCase
         $this->client->jobs['jid']->timeout();
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function shouldTimeoutJob(): void
     {
         $this->client->queues['foo']->put('Foo', [], 'jid');
@@ -306,7 +314,9 @@ class BaseJobTest extends QlessTestCase
         self::assertEquals('timed-out', $job->history[2]['what']);
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function shouldGetCorrectTtl(): void
     {
         $queue = $this->client->queues['test-queue'];
@@ -315,7 +325,9 @@ class BaseJobTest extends QlessTestCase
         self::assertGreaterThan(55, $queue->pop()->ttl());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function shouldCompleteJob(): void
     {
         $queue = $this->client->queues['test-queue'];
@@ -324,7 +336,9 @@ class BaseJobTest extends QlessTestCase
         self::assertEquals('complete', $queue->pop()->complete());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function shouldCompleteJobAndPutItInAnotherQueue(): void
     {
         $queue1 = $this->client->queues['test-queue-1'];
@@ -351,7 +365,9 @@ class BaseJobTest extends QlessTestCase
         self::assertEquals(1, $job2->data['size']);
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function shouldNotPopFailedJob(): void
     {
         $queue = $this->client->queues['test-queue'];
@@ -409,7 +425,9 @@ class BaseJobTest extends QlessTestCase
         self::assertNull($queue->pop());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function shouldCancelRemovesJob(): void
     {
         $queue = $this->client->queues['test-queue'];
@@ -420,7 +438,9 @@ class BaseJobTest extends QlessTestCase
         self::assertEquals(['jid-1'], $queue->pop()->cancel());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function shouldCancelRemovesJobWithDependents(): void
     {
         $queue = $this->client->queues['test-queue'];
@@ -433,8 +453,6 @@ class BaseJobTest extends QlessTestCase
 
     /**
      * @test
-     *
-     *
      */
     public function shouldThrowExceptionOnCancelWithoutDependencies(): void
     {
@@ -448,7 +466,9 @@ class BaseJobTest extends QlessTestCase
         $queue->pop()->cancel();
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function shouldUnlockJobWhenDependenciesIsCompleted(): void
     {
         $queue = $this->client->queues['test-queue'];
@@ -510,8 +530,6 @@ class BaseJobTest extends QlessTestCase
 
     /**
      * @test
-     *
-     *
      */
     public function shouldThrowExceptionWhenGetInaccessibleProperty(): void
     {
@@ -526,7 +544,9 @@ class BaseJobTest extends QlessTestCase
         $job->foo;
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function shouldTreatedLikeAString(): void
     {
         $queue = $this->client->queues['test-queue'];
@@ -540,7 +560,9 @@ class BaseJobTest extends QlessTestCase
         self::assertEquals($expected, $job->__toString());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function shouldProvideAccessToTheDataUsingArrayNotation(): void
     {
         $queue = $this->client->queues['test-queue'];

--- a/tests/Jobs/BaseJobTest.php
+++ b/tests/Jobs/BaseJobTest.php
@@ -193,7 +193,7 @@ class BaseJobTest extends QlessTestCase
      */
     public function shouldThrowIOnCallingHeartbeatForInvalidJob(): void
     {
-        $this->expectExceptionMessageRegExp('Job .* given out to another worker: worker-2 ');
+        $this->expectExceptionMessageRegExp('~Job .* given out to another worker: worker-2~');
         $this->expectException(LostLockException::class);
         $queue = $this->client->queues['test-queue'];
 

--- a/tests/Jobs/CollectionTest.php
+++ b/tests/Jobs/CollectionTest.php
@@ -13,7 +13,9 @@ use Qless\Tests\QlessTestCase;
  */
 class CollectionTest extends QlessTestCase
 {
-    /** @test */
+    /**
+     * @test
+     */
     public function shouldGetTaggedJobs(): void
     {
         self::assertEquals([], $this->client->jobs->tagged('foo'));
@@ -31,7 +33,9 @@ class CollectionTest extends QlessTestCase
         self::assertEquals(['jid-3', 'jid-4'], $this->client->jobs->tagged('foo', 1, 2));
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function shouldGetTrackedJobs(): void
     {
         $this->client->queues['foo']->put('Foo', [], 'jid-1');
@@ -49,7 +53,9 @@ class CollectionTest extends QlessTestCase
         self::assertCount(0, $this->client->jobs->tracked());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function shouldReturnNullForInvalidJobID(): void
     {
         self::assertNull($this->client->jobs['xxx']);
@@ -61,7 +67,9 @@ class CollectionTest extends QlessTestCase
         $this->assertIsJob($this->client->jobs->get('xxx'));
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function shouldDetectIfJobExist(): void
     {
         $jid = substr(md5(uniqid(microtime(true), true)), 0, 16);
@@ -73,8 +81,6 @@ class CollectionTest extends QlessTestCase
 
     /**
      * @test
-     *
-     *
      */
     public function shouldThrowExceptionOnDeletingProperty(): void
     {
@@ -85,8 +91,6 @@ class CollectionTest extends QlessTestCase
 
     /**
      * @test
-     *
-     *
      */
     public function shouldThrowExceptionOnSettingProperty(): void
     {
@@ -104,7 +108,9 @@ class CollectionTest extends QlessTestCase
         self::assertEquals('j-1', $j->jid);
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function shouldReturnExistingJobsKeyedByJobIdentifier(): void
     {
         self::assertEquals([], $this->client->jobs->multiget([]));
@@ -129,7 +135,9 @@ class CollectionTest extends QlessTestCase
         self::assertEmpty($j);
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function shouldReturnCompletedJobs(): void
     {
         $this->put('j-1');
@@ -146,7 +154,9 @@ class CollectionTest extends QlessTestCase
         self::assertEquals(['j-1', 'j-2'], $j);
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function shouldReturnFailedJobs(): void
     {
         $this->put('j-1');

--- a/tests/Jobs/RecurringJobTest.php
+++ b/tests/Jobs/RecurringJobTest.php
@@ -2,6 +2,7 @@
 
 namespace Qless\Tests\Jobs;
 
+use Qless\Exceptions\InvalidArgumentException;
 use Qless\Jobs\JobData;
 use Qless\Tests\QlessTestCase;
 
@@ -19,15 +20,15 @@ class RecurringJobTest extends QlessTestCase
      * @param string $property
      * @param string $type
      */
-    public function shouldGetInternalProperties(string $property, string $type)
+    public function shouldGetInternalProperties(string $property, string $type): void
     {
         $this->client->queues['test-queue']->recur('Foo', [], null, null, 'jid');
         $job = $this->client->jobs['jid'];
 
-        $this->assertEquals($type, gettype($job->{$property}));
+        self::assertEquals($type, gettype($job->{$property}));
     }
 
-    public function jobPropertiesDataProvider()
+    public function jobPropertiesDataProvider(): array
     {
         return [
             ['jid', 'string'],
@@ -44,57 +45,58 @@ class RecurringJobTest extends QlessTestCase
     }
 
     /** @test */
-    public function shouldChangeJobPriority()
+    public function shouldChangeJobPriority(): void
     {
         $this->client->queues['test-queue']->recur('Foo', [], null, null, 'jid');
-        $this->assertEquals(0, $this->client->jobs['jid']->priority);
+        self::assertEquals(0, $this->client->jobs['jid']->priority);
 
         $this->client->jobs['jid']->priority = 10;
-        $this->assertEquals(10, $this->client->jobs['jid']->priority);
+        self::assertEquals(10, $this->client->jobs['jid']->priority);
     }
 
     /** @test */
-    public function shouldChangeJobInterval()
+    public function shouldChangeJobInterval(): void
     {
         $this->client->queues['test-queue']->recur('Foo', [], null, null, 'jid');
-        $this->assertEquals(60, $this->client->jobs['jid']->interval);
+        self::assertEquals(60, $this->client->jobs['jid']->interval);
 
         $this->client->jobs['jid']->interval = 10;
-        $this->assertEquals(10, $this->client->jobs['jid']->interval);
+        self::assertEquals(10, $this->client->jobs['jid']->interval);
     }
 
     /** @test */
-    public function shouldChangeJobRetries()
+    public function shouldChangeJobRetries(): void
     {
         $this->client->queues['test-queue']->recur('Foo', [], null, null, 'jid', 2);
-        $this->assertEquals(2, $this->client->jobs['jid']->retries);
+        self::assertEquals(2, $this->client->jobs['jid']->retries);
 
         $this->client->jobs['jid']->retries = 10;
-        $this->assertEquals(10, $this->client->jobs['jid']->retries);
+        self::assertEquals(10, $this->client->jobs['jid']->retries);
     }
 
     /** @test */
-    public function shouldChangeJobData()
+    public function shouldChangeJobData(): void
     {
         $this->client->queues['test-queue']->recur('Foo', [], null, null, 'jid');
-        $this->assertEquals([], $this->client->jobs['jid']->data->toArray());
+        self::assertEquals([], $this->client->jobs['jid']->data->toArray());
 
         $this->client->jobs['jid']->data = ['foo' => 'bar'];
-        $this->assertEquals(['foo' => 'bar'], $this->client->jobs['jid']->data->toArray());
+        self::assertEquals(['foo' => 'bar'], $this->client->jobs['jid']->data->toArray());
 
         $this->client->jobs['jid']->data = new JobData(['some' => 'payload']);
-        $this->assertEquals(['some' => 'payload'], $this->client->jobs['jid']->data->toArray());
+        self::assertEquals(['some' => 'payload'], $this->client->jobs['jid']->data->toArray());
 
         $this->client->jobs['jid']->data = '{"foo": "bar"}';
-        $this->assertEquals(['foo' => 'bar'], $this->client->jobs['jid']->data->toArray());
+        self::assertEquals(['foo' => 'bar'], $this->client->jobs['jid']->data->toArray());
     }
 
     /**
      * @test
-     * @expectedException \Qless\Exceptions\InvalidArgumentException
+     *
      */
-    public function shouldThrowExceptionWhenSetInvalidData()
+    public function shouldThrowExceptionWhenSetInvalidData(): void
     {
+        $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage(
             "Job's data must be either an array, or a JobData instance, or a JSON string, integer given."
         );
@@ -104,60 +106,60 @@ class RecurringJobTest extends QlessTestCase
     }
 
     /** @test */
-    public function shouldChangeJobKlass()
+    public function shouldChangeJobKlass(): void
     {
         $this->client->queues['test-queue']->recur('Foo', [], null, null, 'jid');
-        $this->assertEquals('Foo', $this->client->jobs['jid']->klass);
+        self::assertEquals('Foo', $this->client->jobs['jid']->klass);
 
         $this->client->jobs['jid']->klass = 'Bar';
-        $this->assertEquals('Bar', $this->client->jobs['jid']->klass);
+        self::assertEquals('Bar', $this->client->jobs['jid']->klass);
     }
 
     /** @test */
-    public function shouldChangeJobBacklog()
+    public function shouldChangeJobBacklog(): void
     {
         $this->client->queues['test-queue']->recur('Foo', [], null, null, 'jid');
-        $this->assertEquals(0, $this->client->jobs['jid']->backlog);
+        self::assertEquals(0, $this->client->jobs['jid']->backlog);
 
         $this->client->jobs['jid']->backlog = 10;
-        $this->assertEquals(10, $this->client->jobs['jid']->backlog);
+        self::assertEquals(10, $this->client->jobs['jid']->backlog);
     }
 
     /** @test */
-    public function shouldRequeueJob()
+    public function shouldRequeueJob(): void
     {
         $this->client->queues['test-queue']->recur('Foo', [], null, null, 'jid');
-        $this->assertEquals('test-queue', $this->client->jobs['jid']->queue);
+        self::assertEquals('test-queue', $this->client->jobs['jid']->queue);
 
         $this->client->jobs['jid']->requeue('bar');
-        $this->assertEquals('bar', $this->client->jobs['jid']->queue);
+        self::assertEquals('bar', $this->client->jobs['jid']->queue);
     }
 
     /** @test */
-    public function shouldCancelJob()
+    public function shouldCancelJob(): void
     {
         $this->client->queues['test-queue']->recur('Foo', [], null, null, 'jid');
 
-        $this->assertEquals(1, $this->client->jobs['jid']->cancel());
-        $this->assertNull($this->client->jobs['jid']);
+        self::assertEquals(1, $this->client->jobs['jid']->cancel());
+        self::assertNull($this->client->jobs['jid']);
     }
 
     /** @test */
-    public function shouldSetTags()
+    public function shouldSetTags(): void
     {
         $this->client->queues['test-queue']->recur('Foo', [], null, null, 'jid');
 
-        $this->assertEquals([], $this->client->jobs['jid']->tags);
+        self::assertEquals([], $this->client->jobs['jid']->tags);
 
         $this->client->jobs['jid']->tag('foo', 'bar');
-        $this->assertEquals(['foo', 'bar'], $this->client->jobs['jid']->tags);
+        self::assertEquals(['foo', 'bar'], $this->client->jobs['jid']->tags);
 
-        $this->assertEquals(['foo', 'bar'], $this->client->jobs['jid']->tags);
+        self::assertEquals(['foo', 'bar'], $this->client->jobs['jid']->tags);
 
         $this->client->jobs['jid']->untag('bar');
-        $this->assertEquals(['foo'], $this->client->jobs['jid']->tags);
+        self::assertEquals(['foo'], $this->client->jobs['jid']->tags);
 
         $this->client->jobs['jid']->untag('baz');
-        $this->assertEquals(['foo'], $this->client->jobs['jid']->tags);
+        self::assertEquals(['foo'], $this->client->jobs['jid']->tags);
     }
 }

--- a/tests/Jobs/RecurringJobTest.php
+++ b/tests/Jobs/RecurringJobTest.php
@@ -44,7 +44,9 @@ class RecurringJobTest extends QlessTestCase
         ];
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function shouldChangeJobPriority(): void
     {
         $this->client->queues['test-queue']->recur('Foo', [], null, null, 'jid');
@@ -54,7 +56,9 @@ class RecurringJobTest extends QlessTestCase
         self::assertEquals(10, $this->client->jobs['jid']->priority);
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function shouldChangeJobInterval(): void
     {
         $this->client->queues['test-queue']->recur('Foo', [], null, null, 'jid');
@@ -64,7 +68,9 @@ class RecurringJobTest extends QlessTestCase
         self::assertEquals(10, $this->client->jobs['jid']->interval);
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function shouldChangeJobRetries(): void
     {
         $this->client->queues['test-queue']->recur('Foo', [], null, null, 'jid', 2);
@@ -74,7 +80,9 @@ class RecurringJobTest extends QlessTestCase
         self::assertEquals(10, $this->client->jobs['jid']->retries);
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function shouldChangeJobData(): void
     {
         $this->client->queues['test-queue']->recur('Foo', [], null, null, 'jid');
@@ -105,7 +113,9 @@ class RecurringJobTest extends QlessTestCase
         $this->client->jobs['jid']->data = 10;
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function shouldChangeJobKlass(): void
     {
         $this->client->queues['test-queue']->recur('Foo', [], null, null, 'jid');
@@ -115,7 +125,9 @@ class RecurringJobTest extends QlessTestCase
         self::assertEquals('Bar', $this->client->jobs['jid']->klass);
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function shouldChangeJobBacklog(): void
     {
         $this->client->queues['test-queue']->recur('Foo', [], null, null, 'jid');
@@ -125,7 +137,9 @@ class RecurringJobTest extends QlessTestCase
         self::assertEquals(10, $this->client->jobs['jid']->backlog);
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function shouldRequeueJob(): void
     {
         $this->client->queues['test-queue']->recur('Foo', [], null, null, 'jid');
@@ -135,7 +149,9 @@ class RecurringJobTest extends QlessTestCase
         self::assertEquals('bar', $this->client->jobs['jid']->queue);
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function shouldCancelJob(): void
     {
         $this->client->queues['test-queue']->recur('Foo', [], null, null, 'jid');
@@ -144,7 +160,9 @@ class RecurringJobTest extends QlessTestCase
         self::assertNull($this->client->jobs['jid']);
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function shouldSetTags(): void
     {
         $this->client->queues['test-queue']->recur('Foo', [], null, null, 'jid');

--- a/tests/Jobs/Reservers/OrderedReserverTest.php
+++ b/tests/Jobs/Reservers/OrderedReserverTest.php
@@ -18,8 +18,6 @@ class OrderedReserverTest extends QlessTestCase
 {
     /**
      * @test
-     *
-     *
      */
     public function shouldThrowExceptionForNoQueuesAndSpec(): void
     {
@@ -28,7 +26,9 @@ class OrderedReserverTest extends QlessTestCase
         new OrderedReserver($this->client->queues, []);
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function shouldReserveJob(): void
     {
         $queue1 = new Queue('queue-1', $this->client);
@@ -54,7 +54,9 @@ class OrderedReserverTest extends QlessTestCase
         self::assertEquals('queue-1:foo', $_SERVER['performed']);
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function shouldGetQueues(): void
     {
         $reserver = new OrderedReserver($this->client->queues, ['queue-1', 'queue-2']);
@@ -65,7 +67,9 @@ class OrderedReserverTest extends QlessTestCase
         );
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function shouldGetDescription(): void
     {
         $reserver = new OrderedReserver($this->client->queues, ['queue-1', 'queue-2']);
@@ -73,7 +77,9 @@ class OrderedReserverTest extends QlessTestCase
         self::assertEquals('queue-1, queue-2 (ordered)', $reserver->getDescription());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function shouldGetNullOnEmptyQueue(): void
     {
         $reserver = new OrderedReserver($this->client->queues, ['queue-1', 'queue-2']);
@@ -81,7 +87,9 @@ class OrderedReserverTest extends QlessTestCase
         self::assertNull($reserver->reserve());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function shouldSortQueues(): void
     {
         $reserver = new OrderedReserver($this->client->queues, ['queue-7', 'queue-20', 'queue-0']);
@@ -92,7 +100,9 @@ class OrderedReserverTest extends QlessTestCase
         self::assertEquals('queue-0, queue-7, queue-20 (ordered)', $reserver->getDescription());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function shouldReserveQueuesBySpec(): void
     {
         $spec = 'eu-(west|east)-\d+';

--- a/tests/Jobs/Reservers/OrderedReserverTest.php
+++ b/tests/Jobs/Reservers/OrderedReserverTest.php
@@ -3,6 +3,7 @@
 namespace Qless\Tests\Jobs\Reservers;
 
 use Psr\Log\NullLogger;
+use Qless\Exceptions\InvalidArgumentException;
 use Qless\Jobs\BaseJob;
 use Qless\Jobs\Reservers\OrderedReserver;
 use Qless\Queues\Queue;
@@ -17,16 +18,18 @@ class OrderedReserverTest extends QlessTestCase
 {
     /**
      * @test
-     * @expectedException \Qless\Exceptions\InvalidArgumentException
-     * @expectedExceptionMessage A queues list or a specification to reserve queues are required.
+     *
+     *
      */
-    public function shouldThrowExceptionForNoQueuesAndSpec()
+    public function shouldThrowExceptionForNoQueuesAndSpec(): void
     {
+        $this->expectExceptionMessage("A queues list or a specification to reserve queues are required.");
+        $this->expectException(InvalidArgumentException::class);
         new OrderedReserver($this->client->queues, []);
     }
 
     /** @test */
-    public function shouldReserveJob()
+    public function shouldReserveJob(): void
     {
         $queue1 = new Queue('queue-1', $this->client);
         $queue2 = new Queue('queue-2', $this->client);
@@ -47,70 +50,70 @@ class OrderedReserverTest extends QlessTestCase
         $job = $reserver->reserve();
 
         $this->assertIsJob($job);
-        $this->assertTrue($job->perform());
-        $this->assertEquals('queue-1:foo', $_SERVER['performed']);
+        self::assertTrue($job->perform());
+        self::assertEquals('queue-1:foo', $_SERVER['performed']);
     }
 
     /** @test */
-    public function shouldGetQueues()
+    public function shouldGetQueues(): void
     {
         $reserver = new OrderedReserver($this->client->queues, ['queue-1', 'queue-2']);
 
-        $this->assertEquals(
+        self::assertEquals(
             [new Queue('queue-1', $this->client), new Queue('queue-2', $this->client)],
             $reserver->getQueues()
         );
     }
 
     /** @test */
-    public function shouldGetDescription()
+    public function shouldGetDescription(): void
     {
         $reserver = new OrderedReserver($this->client->queues, ['queue-1', 'queue-2']);
 
-        $this->assertEquals('queue-1, queue-2 (ordered)', $reserver->getDescription());
+        self::assertEquals('queue-1, queue-2 (ordered)', $reserver->getDescription());
     }
 
     /** @test */
-    public function shouldGetNullOnEmptyQueue()
+    public function shouldGetNullOnEmptyQueue(): void
     {
         $reserver = new OrderedReserver($this->client->queues, ['queue-1', 'queue-2']);
 
-        $this->assertNull($reserver->reserve());
+        self::assertNull($reserver->reserve());
     }
 
     /** @test */
-    public function shouldSortQueues()
+    public function shouldSortQueues(): void
     {
         $reserver = new OrderedReserver($this->client->queues, ['queue-7', 'queue-20', 'queue-0']);
 
-        $this->assertEquals('queue-7, queue-20, queue-0 (ordered)', $reserver->getDescription());
+        self::assertEquals('queue-7, queue-20, queue-0 (ordered)', $reserver->getDescription());
 
         $reserver->beforeWork();
-        $this->assertEquals('queue-0, queue-7, queue-20 (ordered)', $reserver->getDescription());
+        self::assertEquals('queue-0, queue-7, queue-20 (ordered)', $reserver->getDescription());
     }
 
     /** @test */
-    public function shouldReserveQueuesBySpec()
+    public function shouldReserveQueuesBySpec(): void
     {
         $spec = 'eu-(west|east)-\d+';
         $reserver = new OrderedReserver($this->client->queues, null, $spec);
         $reserver->setLogger(new NullLogger());
 
         $this->client->put('w1', 'foo', 'j1', 'klass', '{}', 0);
-        $this->assertNull($reserver->reserve());
+        self::assertNull($reserver->reserve());
 
         $this->client->put('w1', 'eu-west-2', 'j1', 'klass', '{}', 0);
 
         $job = $reserver->reserve();
 
         $this->assertIsJob($job);
-        $this->assertEquals('j1', $job->jid);
+        self::assertEquals('j1', $job->jid);
 
         $job->complete('eu-east-1');
 
         $job = $reserver->reserve();
 
         $this->assertIsJob($job);
-        $this->assertEquals('j1', $job->jid);
+        self::assertEquals('j1', $job->jid);
     }
 }

--- a/tests/Jobs/Reservers/PriorityReserverTest.php
+++ b/tests/Jobs/Reservers/PriorityReserverTest.php
@@ -2,6 +2,7 @@
 
 namespace Qless\Tests\Jobs\Reservers;
 
+use Qless\Exceptions\InvalidArgumentException;
 use Qless\Jobs\BaseJob;
 use Qless\Jobs\Reservers\PriorityReserver;
 use Qless\Queues\Queue;
@@ -16,16 +17,18 @@ class PriorityReserverTest extends QlessTestCase
 {
     /**
      * @test
-     * @expectedException \Qless\Exceptions\InvalidArgumentException
-     * @expectedExceptionMessage A queues list or a specification to reserve queues are required.
+     *
+     *
      */
-    public function shouldThrowExceptionForNoQueuesAndSpec()
+    public function shouldThrowExceptionForNoQueuesAndSpec(): void
     {
+        $this->expectExceptionMessage("A queues list or a specification to reserve queues are required.");
+        $this->expectException(InvalidArgumentException::class);
         new PriorityReserver($this->client->queues, []);
     }
 
     /** @test */
-    public function shouldReserveJob()
+    public function shouldReserveJob(): void
     {
         $queue1 = new Queue('queue-1-', $this->client);
         $queue2 = new Queue('queue-2-', $this->client);
@@ -64,11 +67,11 @@ class PriorityReserverTest extends QlessTestCase
         $reserver->reserve()->perform();
         $reserver->reserve()->perform();
 
-        $this->assertEquals('queue-2-queue-1-queue-4-queue-3', $_SERVER['performed']);
+        self::assertEquals('queue-2-queue-1-queue-4-queue-3', $_SERVER['performed']);
     }
 
     /** @test */
-    public function shouldNormalConstructObjectWithQueuesStack()
+    public function shouldNormalConstructObjectWithQueuesStack(): void
     {
         $queue1 = new Queue('queue-1', $this->client);
         $queue2 = new Queue('queue-2', $this->client);
@@ -77,19 +80,19 @@ class PriorityReserverTest extends QlessTestCase
 
         $reserver = new PriorityReserver($this->client->queues, ['queue-1', 'queue-2']);
 
-        $this->assertEquals($stack, $reserver->getQueues());
+        self::assertEquals($stack, $reserver->getQueues());
     }
 
     /** @test */
-    public function shouldGetDescription()
+    public function shouldGetDescription(): void
     {
         $reserver = new PriorityReserver($this->client->queues, ['queue-1', 'queue-2']);
 
-        $this->assertEquals('queue-1, queue-2 (priority)', $reserver->getDescription());
+        self::assertEquals('queue-1, queue-2 (priority)', $reserver->getDescription());
     }
 
     /** @test */
-    public function shouldOrderByPriorityQueuesBeforeWork()
+    public function shouldOrderByPriorityQueuesBeforeWork(): void
     {
         $reserver = new PriorityReserver(
             $this->client->queues,
@@ -104,17 +107,17 @@ class PriorityReserverTest extends QlessTestCase
 
         $reserver->beforework();
 
-        $this->assertRegExp(
+        self::assertRegExp(
             '#queue-3, queue-2, queue-1 \(priority\)#',
             $reserver->getDescription()
         );
 
-        $this->assertCount(3, $reserver->getQueues());
-        $this->assertContainsOnly(Queue::class, $reserver->getQueues());
+        self::assertCount(3, $reserver->getQueues());
+        self::assertContainsOnly(Queue::class, $reserver->getQueues());
     }
 
     /** @test */
-    public function shouldRangeByPriorityQueuesBeforeWork()
+    public function shouldRangeByPriorityQueuesBeforeWork(): void
     {
         $reserver = new PriorityReserver(
             $this->client->queues,
@@ -132,12 +135,12 @@ class PriorityReserverTest extends QlessTestCase
         $reserver->beforework();
 
         $queues = $reserver->getQueues();
-        $this->assertCount(1, $reserver->getQueues());
-        $this->assertEquals('queue-2', (string) $queues[0]);
+        self::assertCount(1, $reserver->getQueues());
+        self::assertEquals('queue-2', (string) $queues[0]);
     }
 
     /** @test */
-    public function shouldByMinPriorityQueuesBeforeWork()
+    public function shouldByMinPriorityQueuesBeforeWork(): void
     {
         $reserver = new PriorityReserver(
             $this->client->queues,
@@ -154,13 +157,13 @@ class PriorityReserverTest extends QlessTestCase
         $reserver->beforework();
 
         $queues = $reserver->getQueues();
-        $this->assertCount(2, $reserver->getQueues());
-        $this->assertEquals('queue-3', (string) $queues[0]);
-        $this->assertEquals('queue-2', (string) $queues[1]);
+        self::assertCount(2, $reserver->getQueues());
+        self::assertEquals('queue-3', (string) $queues[0]);
+        self::assertEquals('queue-2', (string) $queues[1]);
     }
 
     /** @test */
-    public function shouldByMaxPriorityQueuesBeforeWork()
+    public function shouldByMaxPriorityQueuesBeforeWork(): void
     {
         $reserver = new PriorityReserver(
             $this->client->queues,
@@ -177,8 +180,8 @@ class PriorityReserverTest extends QlessTestCase
         $reserver->beforework();
 
         $queues = $reserver->getQueues();
-        $this->assertCount(2, $reserver->getQueues());
-        $this->assertEquals('queue-2', (string) $queues[0]);
-        $this->assertEquals('queue-1', (string) $queues[1]);
+        self::assertCount(2, $reserver->getQueues());
+        self::assertEquals('queue-2', (string) $queues[0]);
+        self::assertEquals('queue-1', (string) $queues[1]);
     }
 }

--- a/tests/Jobs/Reservers/PriorityReserverTest.php
+++ b/tests/Jobs/Reservers/PriorityReserverTest.php
@@ -17,8 +17,6 @@ class PriorityReserverTest extends QlessTestCase
 {
     /**
      * @test
-     *
-     *
      */
     public function shouldThrowExceptionForNoQueuesAndSpec(): void
     {
@@ -27,7 +25,9 @@ class PriorityReserverTest extends QlessTestCase
         new PriorityReserver($this->client->queues, []);
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function shouldReserveJob(): void
     {
         $queue1 = new Queue('queue-1-', $this->client);
@@ -70,7 +70,9 @@ class PriorityReserverTest extends QlessTestCase
         self::assertEquals('queue-2-queue-1-queue-4-queue-3', $_SERVER['performed']);
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function shouldNormalConstructObjectWithQueuesStack(): void
     {
         $queue1 = new Queue('queue-1', $this->client);
@@ -83,7 +85,9 @@ class PriorityReserverTest extends QlessTestCase
         self::assertEquals($stack, $reserver->getQueues());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function shouldGetDescription(): void
     {
         $reserver = new PriorityReserver($this->client->queues, ['queue-1', 'queue-2']);
@@ -91,7 +95,9 @@ class PriorityReserverTest extends QlessTestCase
         self::assertEquals('queue-1, queue-2 (priority)', $reserver->getDescription());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function shouldOrderByPriorityQueuesBeforeWork(): void
     {
         $reserver = new PriorityReserver(
@@ -116,7 +122,9 @@ class PriorityReserverTest extends QlessTestCase
         self::assertContainsOnly(Queue::class, $reserver->getQueues());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function shouldRangeByPriorityQueuesBeforeWork(): void
     {
         $reserver = new PriorityReserver(
@@ -139,7 +147,9 @@ class PriorityReserverTest extends QlessTestCase
         self::assertEquals('queue-2', (string) $queues[0]);
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function shouldByMinPriorityQueuesBeforeWork(): void
     {
         $reserver = new PriorityReserver(
@@ -162,7 +172,9 @@ class PriorityReserverTest extends QlessTestCase
         self::assertEquals('queue-2', (string) $queues[1]);
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function shouldByMaxPriorityQueuesBeforeWork(): void
     {
         $reserver = new PriorityReserver(

--- a/tests/Jobs/Reservers/RoundRobinReserverTest.php
+++ b/tests/Jobs/Reservers/RoundRobinReserverTest.php
@@ -27,7 +27,9 @@ class RoundRobinReserverTest extends QlessTestCase
         new RoundRobinReserver($this->client->queues, []);
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function shouldReserveJob(): void
     {
         $queue1 = new Queue('queue-1', $this->client);
@@ -82,7 +84,9 @@ class RoundRobinReserverTest extends QlessTestCase
         self::assertEquals('queue-1, queue-2 (round robin)', $reserver->getDescription());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function shouldGetNullOnEmptyQueue(): void
     {
         $reserver = new RoundRobinReserver($this->client->queues, ['queue-1', 'queue-2']);

--- a/tests/Jobs/Reservers/RoundRobinReserverTest.php
+++ b/tests/Jobs/Reservers/RoundRobinReserverTest.php
@@ -2,6 +2,7 @@
 
 namespace Qless\Tests\Jobs\Reservers;
 
+use Qless\Exceptions\InvalidArgumentException;
 use Qless\Jobs\BaseJob;
 use Qless\Jobs\Reservers\RoundRobinReserver;
 use Qless\Queues\Queue;
@@ -14,18 +15,20 @@ use Qless\Tests\QlessTestCase;
  */
 class RoundRobinReserverTest extends QlessTestCase
 {
+
     /**
      * @test
-     * @expectedException \Qless\Exceptions\InvalidArgumentException
-     * @expectedExceptionMessage A queues list or a specification to reserve queues are required.
+     *
      */
-    public function shouldThrowExceptionForNoQueuesAndSpec()
+    public function shouldThrowExceptionForNoQueuesAndSpec(): void
     {
+        $this->expectExceptionMessage("A queues list or a specification to reserve queues are required.");
+        $this->expectException(InvalidArgumentException::class);
         new RoundRobinReserver($this->client->queues, []);
     }
 
     /** @test */
-    public function shouldReserveJob()
+    public function shouldReserveJob(): void
     {
         $queue1 = new Queue('queue-1', $this->client);
         $queue2 = new Queue('queue-2', $this->client);
@@ -36,7 +39,7 @@ class RoundRobinReserverTest extends QlessTestCase
         $class = new class {
             public function perform(BaseJob $job): void
             {
-                $_SERVER['performed'] .= "{$job->data[0]}";
+                $_SERVER['performed'] .= ($job->data[0]);
             }
         };
 
@@ -53,11 +56,12 @@ class RoundRobinReserverTest extends QlessTestCase
         $reserver->reserve()->perform();
         $reserver->reserve()->perform();
 
-        $this->assertEquals('foo-bar-baz', $_SERVER['performed']);
+        self::assertEquals('foo-bar-baz', $_SERVER['performed']);
     }
 
-    /** @test */
-    public function shouldNormalConstructObjectWithQueuesStack()
+    /** @test
+     */
+    public function shouldNormalConstructObjectWithQueuesStack(): void
     {
         $queue1 = new Queue('queue-1', $this->client);
         $queue2 = new Queue('queue-2', $this->client);
@@ -66,22 +70,23 @@ class RoundRobinReserverTest extends QlessTestCase
 
         $reserver = new RoundRobinReserver($this->client->queues, ['queue-1', 'queue-2']);
 
-        $this->assertEquals($stack, $reserver->getQueues());
+        self::assertEquals($stack, $reserver->getQueues());
     }
 
-    /** @test */
-    public function shouldGetDescription()
+    /** @test
+     */
+    public function shouldGetDescription(): void
     {
         $reserver = new RoundRobinReserver($this->client->queues, ['queue-1', 'queue-2']);
 
-        $this->assertEquals('queue-1, queue-2 (round robin)', $reserver->getDescription());
+        self::assertEquals('queue-1, queue-2 (round robin)', $reserver->getDescription());
     }
 
     /** @test */
-    public function shouldGetNullOnEmptyQueue()
+    public function shouldGetNullOnEmptyQueue(): void
     {
         $reserver = new RoundRobinReserver($this->client->queues, ['queue-1', 'queue-2']);
 
-        $this->assertNull($reserver->reserve());
+        self::assertNull($reserver->reserve());
     }
 }

--- a/tests/Jobs/Reservers/ShuffledRoundRobinReserverTest.php
+++ b/tests/Jobs/Reservers/ShuffledRoundRobinReserverTest.php
@@ -2,6 +2,7 @@
 
 namespace Qless\Tests\Jobs\Reservers;
 
+use Qless\Exceptions\InvalidArgumentException;
 use Qless\Jobs\Reservers\ShuffledRoundRobinReserver;
 use Qless\Queues\Queue;
 
@@ -12,18 +13,21 @@ use Qless\Queues\Queue;
  */
 class ShuffledRoundRobinReserverTest extends RoundRobinReserverTest
 {
+
     /**
      * @test
-     * @expectedException \Qless\Exceptions\InvalidArgumentException
-     * @expectedExceptionMessage A queues list or a specification to reserve queues are required.
+     *
      */
-    public function shouldThrowExceptionForNoQueuesAndSpec()
+    public function shouldThrowExceptionForNoQueuesAndSpec(): void
     {
+        $this->expectExceptionMessage("A queues list or a specification to reserve queues are required.");
+        $this->expectException(InvalidArgumentException::class);
         new ShuffledRoundRobinReserver($this->client->queues, []);
     }
 
-    /** @test */
-    public function shouldNormalConstructObjectWithQueuesStack()
+    /** @test
+     */
+    public function shouldNormalConstructObjectWithQueuesStack(): void
     {
         $queue1 = new Queue('queue-1', $this->client);
         $queue2 = new Queue('queue-2', $this->client);
@@ -32,19 +36,20 @@ class ShuffledRoundRobinReserverTest extends RoundRobinReserverTest
 
         $reserver = new ShuffledRoundRobinReserver($this->client->queues, ['queue-1', 'queue-2']);
 
-        $this->assertEquals($stack, $reserver->getQueues());
+        self::assertEquals($stack, $reserver->getQueues());
     }
 
-    /** @test */
-    public function shouldGetDescription()
+    /** @test
+     */
+    public function shouldGetDescription(): void
     {
         $reserver = new ShuffledRoundRobinReserver($this->client->queues, ['queue-1', 'queue-2']);
 
-        $this->assertEquals('queue-1, queue-2 (shuffled round robin)', $reserver->getDescription());
+        self::assertEquals('queue-1, queue-2 (shuffled round robin)', $reserver->getDescription());
     }
 
     /** @test */
-    public function shouldShuffleQueuesBeforeWork()
+    public function shouldShuffleQueuesBeforeWork(): void
     {
         $reserver = new ShuffledRoundRobinReserver(
             $this->client->queues,
@@ -53,12 +58,12 @@ class ShuffledRoundRobinReserverTest extends RoundRobinReserverTest
 
         $reserver->beforework();
 
-        $this->assertRegExp(
+        self::assertRegExp(
             '#queue-\d, queue-\d, queue-\d, queue-\d, queue-\d \(shuffled round robin\)#',
             $reserver->getDescription()
         );
 
-        $this->assertCount(5, $reserver->getQueues());
-        $this->assertContainsOnly(Queue::class, $reserver->getQueues());
+        self::assertCount(5, $reserver->getQueues());
+        self::assertContainsOnly(Queue::class, $reserver->getQueues());
     }
 }

--- a/tests/Jobs/Reservers/ShuffledRoundRobinReserverTest.php
+++ b/tests/Jobs/Reservers/ShuffledRoundRobinReserverTest.php
@@ -48,7 +48,9 @@ class ShuffledRoundRobinReserverTest extends RoundRobinReserverTest
         self::assertEquals('queue-1, queue-2 (shuffled round robin)', $reserver->getDescription());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function shouldShuffleQueuesBeforeWork(): void
     {
         $reserver = new ShuffledRoundRobinReserver(

--- a/tests/LuaScriptTest.php
+++ b/tests/LuaScriptTest.php
@@ -55,8 +55,6 @@ class LuaScriptTest extends QlessTestCase
 
     /**
      * @test
-     *
-     *
      */
     public function shouldThrowExpectedExceptionWhenLuaCoreDoesNotExists(): void {
         $this->expectExceptionMessageRegExp('~Unable to locate qless-core file at path: .*~');

--- a/tests/LuaScriptTest.php
+++ b/tests/LuaScriptTest.php
@@ -59,7 +59,7 @@ class LuaScriptTest extends QlessTestCase
      *
      */
     public function shouldThrowExpectedExceptionWhenLuaCoreDoesNotExists(): void {
-        $this->expectExceptionMessageRegExp('Unable to locate qless-core file at path: .*');
+        $this->expectExceptionMessageRegExp('~Unable to locate qless-core file at path: .*~');
         $this->expectException(RuntimeException::class);
         $luaScript = new LuaScript($this->redis());
 

--- a/tests/LuaScriptTest.php
+++ b/tests/LuaScriptTest.php
@@ -2,6 +2,7 @@
 
 namespace Qless\Tests;
 
+use Qless\Exceptions\RuntimeException;
 use Qless\LuaScript;
 use Qless\Tests\Support\RedisAwareTrait;
 
@@ -54,11 +55,12 @@ class LuaScriptTest extends QlessTestCase
 
     /**
      * @test
-     * @expectedException \Qless\Exceptions\RuntimeException
-     * @expectedExceptionMessageRegExp "Unable to locate qless-core file at path: .*"
+     *
+     *
      */
-    public function shouldThrowExpectedExceptionWhenLuaCoreDoesNotExists()
-    {
+    public function shouldThrowExpectedExceptionWhenLuaCoreDoesNotExists(): void {
+        $this->expectExceptionMessageRegExp('Unable to locate qless-core file at path: .*');
+        $this->expectException(RuntimeException::class);
         $luaScript = new LuaScript($this->redis());
 
         $luaScript->run('some-command', []);

--- a/tests/PubSub/DummyPubSubJob.php
+++ b/tests/PubSub/DummyPubSubJob.php
@@ -4,6 +4,8 @@ namespace Qless\Tests\PubSub;
 
 use Qless\Jobs\BaseJob;
 use Qless\PubSub\Manager;
+use function fwrite;
+use function sleep;
 
 class DummyPubSubJob
 {
@@ -27,7 +29,7 @@ class DummyPubSubJob
                 break;
             case Manager::EVENT_STALLED:
                 if ($job->retries === $job->remaining) {
-                    \sleep($job->ttl() + 1);
+                    sleep($job->ttl() + 1);
                 }
                 break;
             case Manager::EVENT_UNTRACK:
@@ -39,7 +41,7 @@ class DummyPubSubJob
                 break;
 
             default:
-                \fwrite(STDERR, 'Invalid job type provided: ' . var_export($type, true) . PHP_EOL);
+                fwrite(STDERR, 'Invalid job type provided: ' . var_export($type, true) . PHP_EOL);
         }
     }
 }

--- a/tests/PubSub/ManagerTest.php
+++ b/tests/PubSub/ManagerTest.php
@@ -177,6 +177,6 @@ class ManagerTest extends QlessTestCase
         $messagesReceived = explode(PHP_EOL, $this->getBackgroundStdOut());
         $this->stopBackgroundTask();
 
-        $this->assertContains($expectedMessage, $messagesReceived, 'Expected events of type ' . $type);
+        self::assertContains($expectedMessage, $messagesReceived, 'Expected events of type ' . $type);
     }
 }

--- a/tests/PubSub/ManagerTest.php
+++ b/tests/PubSub/ManagerTest.php
@@ -41,7 +41,9 @@ class ManagerTest extends QlessTestCase
      */
     protected $process;
 
-    /** @test */
+    /**
+     * @test
+     */
     public function shouldNotAcceptOtherEvents(): void
     {
         $this->expectException(\InvalidArgumentException::class);
@@ -50,49 +52,65 @@ class ManagerTest extends QlessTestCase
         });
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function shouldReceiveCanceledEvent(): void
     {
         $this->shouldReceivedExpectedMessageType(Manager::EVENT_CANCELED);
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function shouldReceiveCompletedEvent(): void
     {
         $this->shouldReceivedExpectedMessageType(Manager::EVENT_COMPLETED);
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function shouldReceiveFailedEvent(): void
     {
         $this->shouldReceivedExpectedMessageType(Manager::EVENT_FAILED);
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function shouldReceivePoppedEvent(): void
     {
         $this->shouldReceivedExpectedMessageType(Manager::EVENT_POPPED);
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function shouldReceiveStalledEvent(): void
     {
         $this->shouldReceivedExpectedMessageType(Manager::EVENT_STALLED);
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function shouldReceivePutEvent(): void
     {
         $this->shouldReceivedExpectedMessageType(Manager::EVENT_PUT);
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function shouldReceiveTrackEvent(): void
     {
         $this->shouldReceivedExpectedMessageType(Manager::EVENT_TRACK);
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function shouldReceiveUntrackEvent(): void
     {
         $this->shouldReceivedExpectedMessageType(Manager::EVENT_UNTRACK);

--- a/tests/QlessTestCase.php
+++ b/tests/QlessTestCase.php
@@ -7,6 +7,7 @@ use PHPUnit\Framework\TestCase;
 use Qless\Client;
 use Qless\Jobs\BaseJob;
 use Qless\Tests\Support\RedisAwareTrait;
+use SebastianBergmann\RecursionContext\InvalidArgumentException;
 
 /**
  * Qless\Tests\QlessTestCase
@@ -63,11 +64,11 @@ abstract class QlessTestCase extends TestCase
      * @param string $message
      *
      * @throws ExpectationFailedException
-     * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
+     * @throws InvalidArgumentException
      */
     public function assertZero($condition, string $message = ''): void
     {
-        $this->assertEquals(0, $condition, $message);
+        self::assertEquals(0, $condition, $message);
     }
 
     /**
@@ -77,10 +78,10 @@ abstract class QlessTestCase extends TestCase
      * @param string $message
      *
      * @throws ExpectationFailedException
-     * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
+     * @throws InvalidArgumentException
      */
-    public function assertIsJob($condition, string $message = '')
+    public function assertIsJob($condition, string $message = ''): void
     {
-        $this->assertInstanceOf(BaseJob::class, $condition, $message);
+        self::assertInstanceOf(BaseJob::class, $condition, $message);
     }
 }

--- a/tests/Queues/CollectionTest.php
+++ b/tests/Queues/CollectionTest.php
@@ -16,7 +16,9 @@ use Qless\Queues\Collection;
  */
 class CollectionTest extends QlessTestCase
 {
-    /** @test */
+    /**
+     * @test
+     */
     public function shouldGetQueuesList(): void
     {
         $collection = new Collection($this->client);
@@ -42,8 +44,6 @@ class CollectionTest extends QlessTestCase
 
     /**
      * @test
-     *
-     *
      */
     public function shouldThrowExceptionWhenGetInaccessibleProperty(): void
     {
@@ -54,7 +54,9 @@ class CollectionTest extends QlessTestCase
         $collection->foo;
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function shouldCheckWhetherAOffsetExists(): void
     {
         $collection = new Collection($this->client);
@@ -68,7 +70,9 @@ class CollectionTest extends QlessTestCase
         self::assertFalse(isset($collection['bar']));
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function shouldGetQueues(): void
     {
         $collection = new Collection($this->client);
@@ -92,8 +96,6 @@ class CollectionTest extends QlessTestCase
 
     /**
      * @test
-     *
-     *
      */
     public function shouldRemoveEmptyQueueOnDeletingProperty(): void
     {
@@ -110,17 +112,17 @@ class CollectionTest extends QlessTestCase
 
     /**
      * @test
-     * @expectedException \Qless\Exceptions\UnsupportedFeatureException
-        $this->expectExceptionMessage("Setting a queue is not supported using Queues collection.");
      */
-    public function shouldThrowExceptionOnSettingProperty()
+    public function shouldThrowExceptionOnSettingProperty(): void
     {
         $this->expectException(UnsupportedFeatureException::class);
         $collection = new Collection($this->client);
         $collection['foo'] = 'bar';
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function shouldGetQueuesListBySpecification(): void
     {
         $pattern = 'eu-(west|east)-\d+';

--- a/tests/Queues/CollectionTest.php
+++ b/tests/Queues/CollectionTest.php
@@ -3,6 +3,8 @@
 namespace Qless\Tests\Queues;
 
 use Qless\Exceptions\QlessException;
+use Qless\Exceptions\UnknownPropertyException;
+use Qless\Exceptions\UnsupportedFeatureException;
 use Qless\Queues\Queue;
 use Qless\Tests\QlessTestCase;
 use Qless\Queues\Collection;
@@ -15,10 +17,10 @@ use Qless\Queues\Collection;
 class CollectionTest extends QlessTestCase
 {
     /** @test */
-    public function shouldGetQueuesList()
+    public function shouldGetQueuesList(): void
     {
         $collection = new Collection($this->client);
-        $this->assertEquals([], $collection->counts);
+        self::assertEquals([], $collection->counts);
 
         $this->client->put('w1', 'test-queue', 'j1', 'klass', '{}', 0);
 
@@ -35,40 +37,43 @@ class CollectionTest extends QlessTestCase
             ]
         ];
 
-        $this->assertEquals($expected, $collection->counts);
+        self::assertEquals($expected, $collection->counts);
     }
 
     /**
      * @test
-     * @expectedException \Qless\Exceptions\UnknownPropertyException
-     * @expectedExceptionMessage Getting unknown property: Qless\Queues\Collection::foo
+     *
+     *
      */
-    public function shouldThrowExceptionWhenGetInaccessibleProperty()
+    public function shouldThrowExceptionWhenGetInaccessibleProperty(): void
     {
+        $this->expectExceptionMessage("Getting unknown property: Qless\Queues\Collection::foo");
+        $this->expectException(UnknownPropertyException::class);
         $collection = new Collection($this->client);
+        /** @noinspection PhpUndefinedFieldInspection */
         $collection->foo;
     }
 
     /** @test */
-    public function shouldCheckWhetherAOffsetExists()
+    public function shouldCheckWhetherAOffsetExists(): void
     {
         $collection = new Collection($this->client);
 
-        $this->assertFalse(isset($collection['foo']));
-        $this->assertFalse(isset($collection['bar']));
+        self::assertFalse(isset($collection['foo']));
+        self::assertFalse(isset($collection['bar']));
 
         $this->client->put('w1', 'foo', 'j1', 'klass', '{}', 0);
 
-        $this->assertTrue(isset($collection['foo']));
-        $this->assertFalse(isset($collection['bar']));
+        self::assertTrue(isset($collection['foo']));
+        self::assertFalse(isset($collection['bar']));
     }
 
     /** @test */
-    public function shouldGetQueues()
+    public function shouldGetQueues(): void
     {
         $collection = new Collection($this->client);
 
-        $this->assertInstanceOf(Queue::class, $collection['q1']);
+        self::assertInstanceOf(Queue::class, $collection['q1']);
     }
 
     /**
@@ -87,6 +92,8 @@ class CollectionTest extends QlessTestCase
 
     /**
      * @test
+     *
+     *
      */
     public function shouldRemoveEmptyQueueOnDeletingProperty(): void
     {
@@ -104,40 +111,41 @@ class CollectionTest extends QlessTestCase
     /**
      * @test
      * @expectedException \Qless\Exceptions\UnsupportedFeatureException
-     * @expectedExceptionMessage Setting a queue is not supported using Queues collection.
+        $this->expectExceptionMessage("Setting a queue is not supported using Queues collection.");
      */
     public function shouldThrowExceptionOnSettingProperty()
     {
+        $this->expectException(UnsupportedFeatureException::class);
         $collection = new Collection($this->client);
         $collection['foo'] = 'bar';
     }
 
     /** @test */
-    public function shouldGetQueuesListBySpecification()
+    public function shouldGetQueuesListBySpecification(): void
     {
         $pattern = 'eu-(west|east)-\d+';
         $collection = new Collection($this->client);
 
-        $this->assertEquals([], $collection->fromSpec($pattern));
+        self::assertEquals([], $collection->fromSpec($pattern));
 
         $this->client->put('w1', 'foo', 'j1', 'klass', '{}', 0);
-        $this->assertEquals([], $collection->fromSpec($pattern));
+        self::assertEquals([], $collection->fromSpec($pattern));
 
         $this->client->put('w1', 'eu-west-2', 'j1', 'klass', '{}', 0);
         $queues = $collection->fromSpec($pattern);
 
-        $this->assertTrue(is_array($queues));
-        $this->assertInstanceOf(Queue::class, $queues[0]);
-        $this->assertCount(1, $queues);
-        $this->assertEquals('eu-west-2', (string) $queues[0]);
+        self::assertIsArray($queues);
+        self::assertInstanceOf(Queue::class, $queues[0]);
+        self::assertCount(1, $queues);
+        self::assertEquals('eu-west-2', (string) $queues[0]);
 
         $this->client->put('w1', 'eu-east-1', 'j1', 'klass', '{}', 0);
         $queues = $collection->fromSpec($pattern);
 
-        $this->assertCount(2, $queues);
-        $this->assertEquals('eu-west-2', (string) $queues[0]);
-        $this->assertEquals('eu-east-1', (string) $queues[1]);
+        self::assertCount(2, $queues);
+        self::assertEquals('eu-west-2', (string) $queues[0]);
+        self::assertEquals('eu-east-1', (string) $queues[1]);
 
-        $this->assertEquals([], $collection->fromSpec(''));
+        self::assertEquals([], $collection->fromSpec(''));
     }
 }

--- a/tests/Queues/QueueTest.php
+++ b/tests/Queues/QueueTest.php
@@ -13,7 +13,9 @@ use Qless\Queues\Queue;
  */
 class QueueTest extends QlessTestCase
 {
-    /** @test */
+    /**
+     * @test
+     */
     public function shouldPutAndPopAJob(): void
     {
         $queue = new Queue('test-queue', $this->client);
@@ -26,20 +28,26 @@ class QueueTest extends QlessTestCase
         self::assertEquals('jid', $job->jid);
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function shouldGenerateAJobIdIfNotProvided(): void
     {
         $queue = new Queue('test-queue', $this->client);
         self::assertRegExp('/^[[:xdigit:]]{32}$/', $queue->put('Xxx\Yyy', []));
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function shouldGetNullWithoutAnyJobInTheQueue(): void
     {
         self::assertNull((new Queue('test-queue', $this->client))->pop());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function shouldGetTheQueueLength(): void
     {
         $queue = new Queue('test-queue', $this->client);
@@ -51,7 +59,9 @@ class QueueTest extends QlessTestCase
         self::assertEquals(10, $queue->length());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function shouldPopMultipleJobs(): void
     {
         $queue = new Queue('test-queue-2', $this->client);
@@ -63,7 +73,9 @@ class QueueTest extends QlessTestCase
         self::assertCount(10, $queue->pop(null, 10));
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function shouldPutAndPopInTheSameOrder(): void
     {
         $queue = new Queue('test-queue', $this->client);
@@ -86,7 +98,9 @@ class QueueTest extends QlessTestCase
         self::assertEquals($putJids, $popJids);
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function shouldPutJobWithPriority(): void
     {
         $queue = new Queue('test-queue', $this->client);
@@ -106,7 +120,9 @@ class QueueTest extends QlessTestCase
         self::assertEquals(0, $job->priority);
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function shouldPopJobsWithHigherPriorityFirst(): void
     {
         $queue = new Queue('test-queue', $this->client);
@@ -133,7 +149,9 @@ class QueueTest extends QlessTestCase
         self::assertEquals(array_reverse($putJids), $popJids);
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function shouldScheduleJob(): void
     {
         $queue = new Queue('test-queue', $this->client);

--- a/tests/Queues/QueueTest.php
+++ b/tests/Queues/QueueTest.php
@@ -14,7 +14,7 @@ use Qless\Queues\Queue;
 class QueueTest extends QlessTestCase
 {
     /** @test */
-    public function shouldPutAndPopAJob()
+    public function shouldPutAndPopAJob(): void
     {
         $queue = new Queue('test-queue', $this->client);
 
@@ -23,24 +23,24 @@ class QueueTest extends QlessTestCase
         $job = $queue->pop();
 
         $this->assertIsJob($job);
-        $this->assertEquals('jid', $job->jid);
+        self::assertEquals('jid', $job->jid);
     }
 
     /** @test */
-    public function shouldGenerateAJobIdIfNotProvided()
+    public function shouldGenerateAJobIdIfNotProvided(): void
     {
         $queue = new Queue('test-queue', $this->client);
-        $this->assertRegExp('/^[[:xdigit:]]{32}$/', $queue->put('Xxx\Yyy', []));
+        self::assertRegExp('/^[[:xdigit:]]{32}$/', $queue->put('Xxx\Yyy', []));
     }
 
     /** @test */
-    public function shouldGetNullWithoutAnyJobInTheQueue()
+    public function shouldGetNullWithoutAnyJobInTheQueue(): void
     {
-        $this->assertNull((new Queue('test-queue', $this->client))->pop());
+        self::assertNull((new Queue('test-queue', $this->client))->pop());
     }
 
     /** @test */
-    public function shouldGetTheQueueLength()
+    public function shouldGetTheQueueLength(): void
     {
         $queue = new Queue('test-queue', $this->client);
 
@@ -48,11 +48,11 @@ class QueueTest extends QlessTestCase
             $queue->put('SampleClass', [], "jid-{$id}");
         }, range(1, 10));
 
-        $this->assertEquals(10, $queue->length());
+        self::assertEquals(10, $queue->length());
     }
 
     /** @test */
-    public function shouldPopMultipleJobs()
+    public function shouldPopMultipleJobs(): void
     {
         $queue = new Queue('test-queue-2', $this->client);
 
@@ -60,11 +60,11 @@ class QueueTest extends QlessTestCase
             $queue->put('Xxx\Yyy', [], "jid-{$jid}");
         }
 
-        $this->assertCount(10, $queue->pop(null, 10));
+        self::assertCount(10, $queue->pop(null, 10));
     }
 
     /** @test */
-    public function shouldPutAndPopInTheSameOrder()
+    public function shouldPutAndPopInTheSameOrder(): void
     {
         $queue = new Queue('test-queue', $this->client);
 
@@ -77,37 +77,37 @@ class QueueTest extends QlessTestCase
             return $queue->pop()->jid;
         }, $putJids);
 
-        $this->assertTrue(is_array($putJids));
-        $this->assertTrue(is_array($popJids));
+        self::assertIsArray($putJids);
+        self::assertIsArray($popJids);
 
-        $this->assertCount(10, $putJids);
-        $this->assertCount(10, $popJids);
+        self::assertCount(10, $putJids);
+        self::assertCount(10, $popJids);
 
-        $this->assertEquals($putJids, $popJids);
+        self::assertEquals($putJids, $popJids);
     }
 
     /** @test */
-    public function shouldPutJobWithPriority()
+    public function shouldPutJobWithPriority(): void
     {
         $queue = new Queue('test-queue', $this->client);
 
         $jid = $queue->put('SampleHandler', [], null, null, null, -10);
         $job = $queue->pop();
 
-        $this->assertEquals($jid, $job->jid);
-        $this->assertEquals(-10, $job->priority);
+        self::assertEquals($jid, $job->jid);
+        self::assertEquals(-10, $job->priority);
 
         $job->complete();
 
         $jid = $queue->put('SampleHandler', []);
         $job = $queue->pop();
 
-        $this->assertEquals($jid, $job->jid);
-        $this->assertEquals(0, $job->priority);
+        self::assertEquals($jid, $job->jid);
+        self::assertEquals(0, $job->priority);
     }
 
     /** @test */
-    public function shouldPopJobsWithHigherPriorityFirst()
+    public function shouldPopJobsWithHigherPriorityFirst(): void
     {
         $queue = new Queue('test-queue', $this->client);
 
@@ -124,66 +124,66 @@ class QueueTest extends QlessTestCase
             return $queue->pop()->jid;
         }, $putJids);
 
-        $this->assertTrue(is_array($putJids));
-        $this->assertTrue(is_array($popJids));
+        self::assertIsArray($putJids);
+        self::assertIsArray($popJids);
 
-        $this->assertCount(10, $putJids);
-        $this->assertCount(10, $popJids);
+        self::assertCount(10, $putJids);
+        self::assertCount(10, $popJids);
 
-        $this->assertEquals(array_reverse($putJids), $popJids);
+        self::assertEquals(array_reverse($putJids), $popJids);
     }
 
     /** @test */
-    public function shouldScheduleJob()
+    public function shouldScheduleJob(): void
     {
         $queue = new Queue('test-queue', $this->client);
         $queue->put('MyJobClass', ['foo' => 'bar'], null, 1);
 
-        $this->assertNull($queue->pop());
+        self::assertNull($queue->pop());
 
         sleep(1);
         $this->assertIsJob($queue->pop());
     }
 
-    public function testRunningJobIsReplaced()
+    public function testRunningJobIsReplaced(): void
     {
         $queue = new Queue('test-queue', $this->client);
 
-        $this->assertEquals('jid-1', $queue->put('Xxx\Yyy', [], "jid-1"));
+        self::assertEquals('jid-1', $queue->put('Xxx\Yyy', [], "jid-1"));
 
         $queue->pop();
 
-        $this->assertEquals(
+        self::assertEquals(
             'jid-1',
             $queue->put('Xxx\Yyy', [], "jid-1")
         );
     }
 
-    public function testPausedQueueDoesNotReturnJobs()
+    public function testPausedQueueDoesNotReturnJobs(): void
     {
         $queue = new Queue('test-queue', $this->client);
         $queue->pause();
         $queue->put('Xxx\Yyy', []);
 
-        $this->assertNull($queue->pop());
+        self::assertNull($queue->pop());
     }
 
-    public function testQueueIsNotPausedByDefault()
+    public function testQueueIsNotPausedByDefault(): void
     {
         $queue = new Queue('test-queue', $this->client);
         $val = $queue->isPaused();
-        $this->assertFalse($val);
+        self::assertFalse($val);
     }
 
-    public function testQueueCorrectlyReportsIsPaused()
+    public function testQueueCorrectlyReportsIsPaused(): void
     {
         $queue = new Queue('test-queue', $this->client);
         $queue->pause();
         $val = $queue->isPaused();
-        $this->assertTrue($val);
+        self::assertTrue($val);
     }
 
-    public function testPausedQueueThatIsResumedDoesReturnJobs()
+    public function testPausedQueueThatIsResumedDoesReturnJobs(): void
     {
         $queue = new Queue('test-queue', $this->client);
         $queue->pause();
@@ -193,7 +193,7 @@ class QueueTest extends QlessTestCase
         $this->assertIsJob($queue->pop());
     }
 
-    public function testHighPriorityJobPoppedBeforeLowerPriorityJobs()
+    public function testHighPriorityJobPoppedBeforeLowerPriorityJobs(): void
     {
         $queue = new Queue('test-queue', $this->client);
 
@@ -204,32 +204,32 @@ class QueueTest extends QlessTestCase
         $queue->put('Xxx\Yyy', $data, "jid-high", 0, 0, 1);
         $queue->put('Xxx\Yyy', $data, "jid-3");
 
-        $this->assertEquals('jid-high', $queue->pop()->jid);
+        self::assertEquals('jid-high', $queue->pop()->jid);
     }
 
-    public function testItUsesGlobalHeartbeatValueWhenNotSet()
+    public function testItUsesGlobalHeartbeatValueWhenNotSet(): void
     {
         $this->client->config->set('heartbeat', 10);
         $queue = new Queue('test-queue', $this->client);
 
-        $this->assertSame(10, $queue->heartbeat);
+        self::assertSame(10, $queue->heartbeat);
     }
 
-    public function testItUsesOwnHeartbeatValue()
+    public function testItUsesOwnHeartbeatValue(): void
     {
         $queue = new Queue('test-queue', $this->client);
         $queue->heartbeat = 55;
 
-        $this->assertSame(55, $queue->heartbeat);
+        self::assertSame(55, $queue->heartbeat);
     }
 
-    public function testItCanUnsetHeartbeatValueForQueue()
+    public function testItCanUnsetHeartbeatValueForQueue(): void
     {
         $queue = new Queue('test-queue', $this->client);
         $queue->heartbeat = 10;
-        $this->assertSame(10, $queue->heartbeat);
+        self::assertSame(10, $queue->heartbeat);
         unset($queue->heartbeat);
-        $this->assertSame(60, $queue->heartbeat);
+        self::assertSame(60, $queue->heartbeat);
     }
 
     public function testItCanForgetEmptyQueue()

--- a/tests/Signals/SignalHandlerTest.php
+++ b/tests/Signals/SignalHandlerTest.php
@@ -19,9 +19,9 @@ class SignalHandlerTest extends QlessTestCase
      * @param int    $signal
      * @param string $expected
      */
-    public function shouldGetSignalName(int $signal, string $expected)
+    public function shouldGetSignalName(int $signal, string $expected): void
     {
-        $this->assertEquals($expected, SignalHandler::sigName($signal));
+        self::assertEquals($expected, SignalHandler::sigName($signal));
     }
 
     public function signalDataProvider(): array

--- a/tests/Stubs/EventsDrivenJobHandler.php
+++ b/tests/Stubs/EventsDrivenJobHandler.php
@@ -22,7 +22,7 @@ class EventsDrivenJobHandler implements EventsManagerAwareInterface, PerformAwar
         $_SERVER['caller'] = ['stack' => []];
     }
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->getEventsManager()->attach(
             JobEvent\BeforePerform::getName(),

--- a/tests/Stubs/JobSubscriber.php
+++ b/tests/Stubs/JobSubscriber.php
@@ -3,6 +3,7 @@
 namespace Qless\Tests\Stubs;
 
 use Qless\Events\User\Job\AbstractJobEvent;
+use stdClass;
 
 /**
  * Qless\Tests\Stubs\JobSubscriber
@@ -13,7 +14,7 @@ class JobSubscriber
 {
     private $status;
 
-    public function __construct(\stdClass $status)
+    public function __construct(stdClass $status)
     {
         $this->status = $status;
     }

--- a/tests/Stubs/PerformClassAwareWorker.php
+++ b/tests/Stubs/PerformClassAwareWorker.php
@@ -4,6 +4,7 @@ namespace Qless\Tests\Stubs;
 
 use Qless\Events\User\Job as JobEvent;
 use Qless\Workers\AbstractWorker;
+use RuntimeException;
 
 /**
  * Qless\Tests\Stubs\PerformClassAwareWorker
@@ -15,7 +16,7 @@ class PerformClassAwareWorker extends AbstractWorker
     public function perform(): void
     {
         if (!$this->jobPerformHandler) {
-            throw new \RuntimeException('Job handler not set');
+            throw new RuntimeException('Job handler not set');
         }
 
         $job = $this->reserve();

--- a/tests/Stubs/SimpleTestWorker.php
+++ b/tests/Stubs/SimpleTestWorker.php
@@ -4,6 +4,7 @@ namespace Qless\Tests\Stubs;
 
 use Qless\Events\User\Job as JobEvent;
 use Qless\Workers\AbstractWorker;
+use Throwable;
 
 class SimpleTestWorker extends AbstractWorker
 {
@@ -54,7 +55,7 @@ class SimpleTestWorker extends AbstractWorker
             $this->stopWhenTimeLimitIsReached();
 
             // Don't wait on any processes if we're already in shutdown mode.
-            if ($this->isShuttingDown() == true) {
+            if ($this->isShuttingDown() === true) {
                 break;
             }
 
@@ -69,7 +70,7 @@ class SimpleTestWorker extends AbstractWorker
 
             try {
                 $job->perform();
-            } catch (\Throwable $e) {
+            } catch (Throwable $e) {
                 $loggerContext['stack'] = $e->getMessage();
                 $this->logger->critical('{type}: job {job} has failed {stack}', $loggerContext);
 

--- a/tests/Support/RedisAwareTrait.php
+++ b/tests/Support/RedisAwareTrait.php
@@ -22,7 +22,7 @@ trait RedisAwareTrait
      */
     protected function redis(bool $recreate = false): Redis
     {
-        if ($this->instance instanceof Redis == false || $recreate === true) {
+        if ($this->instance instanceof Redis === false || $recreate === true) {
             $config = $this->getRedisConfig();
 
             $this->instance = new Redis(

--- a/tests/Topics/TopicTest.php
+++ b/tests/Topics/TopicTest.php
@@ -12,7 +12,9 @@ class TopicTest extends QlessTestCase
 {
     use RedisAwareTrait;
 
-    /** @test */
+    /**
+     * @test
+     */
     public function shouldGetQueuesBySubscription(): void
     {
         $queues = [];
@@ -41,7 +43,9 @@ class TopicTest extends QlessTestCase
         $queues[2]->unsubscribe('big.*.apples');
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function shouldQueueSubscribe(): void
     {
         $queues = [];
@@ -72,7 +76,9 @@ class TopicTest extends QlessTestCase
         self::assertEquals('Xxx\Yyy', $job5->getKlass());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function shouldQueueUnSubscribe(): void
     {
         $queues = [];

--- a/tests/Topics/TopicTest.php
+++ b/tests/Topics/TopicTest.php
@@ -13,7 +13,7 @@ class TopicTest extends QlessTestCase
     use RedisAwareTrait;
 
     /** @test */
-    public function shouldGetQueuesBySubscription()
+    public function shouldGetQueuesBySubscription(): void
     {
         $queues = [];
         for ($i = 1; $i<=2; $i++) {
@@ -33,16 +33,16 @@ class TopicTest extends QlessTestCase
         $queuesRedApples = $queuesCollection->fromSubscriptions('big.red.apples');
         sort($queuesRedApples);
 
-        $this->assertEquals($queuesExpected, $queuesGreenApples);
-        $this->assertEquals($queuesExpected, $queuesRedApples);
-        $this->assertEquals([], $queuesCollection->fromSubscriptions('*.*.oranges'));
+        self::assertEquals($queuesExpected, $queuesGreenApples);
+        self::assertEquals($queuesExpected, $queuesRedApples);
+        self::assertEquals([], $queuesCollection->fromSubscriptions('*.*.oranges'));
 
         $queues[1]->unsubscribe('big.*.*');
         $queues[2]->unsubscribe('big.*.apples');
     }
 
     /** @test */
-    public function shouldQueueSubscribe()
+    public function shouldQueueSubscribe(): void
     {
         $queues = [];
         for ($i = 1; $i<=5; $i++) {
@@ -65,15 +65,15 @@ class TopicTest extends QlessTestCase
         $job4 = $queues[4]->pop();
         $job5 = $queues[5]->pop();
 
-        $this->assertEquals('Xxx\Yyy', $job1->getKlass());
-        $this->assertEquals('Xxx\Yyy', $job2->getKlass());
-        $this->assertEquals('Xxx\Yyy', $job3->getKlass());
-        $this->assertEmpty($job4);
-        $this->assertEquals('Xxx\Yyy', $job5->getKlass());
+        self::assertEquals('Xxx\Yyy', $job1->getKlass());
+        self::assertEquals('Xxx\Yyy', $job2->getKlass());
+        self::assertEquals('Xxx\Yyy', $job3->getKlass());
+        self::assertEmpty($job4);
+        self::assertEquals('Xxx\Yyy', $job5->getKlass());
     }
 
     /** @test */
-    public function shouldQueueUnSubscribe()
+    public function shouldQueueUnSubscribe(): void
     {
         $queues = [];
         for ($i = 1; $i<=3; $i++) {
@@ -95,8 +95,8 @@ class TopicTest extends QlessTestCase
         $job2 = $queues[2]->pop();
         $job3 = $queues[3]->pop();
 
-        $this->assertEquals('Xxx\Yyy', $job1->getKlass());
-        $this->assertEmpty($job2);
-        $this->assertEquals('Xxx\Yyy', $job3->getKlass());
+        self::assertEquals('Xxx\Yyy', $job1->getKlass());
+        self::assertEmpty($job2);
+        self::assertEquals('Xxx\Yyy', $job3->getKlass());
     }
 }

--- a/tests/Workers/CollectionTest.php
+++ b/tests/Workers/CollectionTest.php
@@ -15,7 +15,9 @@ use Qless\Workers\Collection;
  */
 class CollectionTest extends QlessTestCase
 {
-    /** @test */
+    /**
+     * @test
+     */
     public function shouldGetWorkersList(): void
     {
         $collection = new Collection($this->client);
@@ -27,8 +29,6 @@ class CollectionTest extends QlessTestCase
 
     /**
      * @test
-     *
-     *
      */
     public function shouldThrowExceptionWhenGetInaccessibleProperty(): void
     {
@@ -39,7 +39,9 @@ class CollectionTest extends QlessTestCase
         $collection->foo;
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function shouldCheckWhetherAOffsetExists(): void
     {
         $collection = new Collection($this->client);
@@ -53,7 +55,9 @@ class CollectionTest extends QlessTestCase
         self::assertFalse(isset($collection['bar']));
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function shouldGetWorker(): void
     {
         $collection = new Collection($this->client);
@@ -69,8 +73,6 @@ class CollectionTest extends QlessTestCase
 
     /**
      * @test
-     *
-     *
      */
     public function shouldThrowExceptionOnDeletingProperty(): void
     {
@@ -82,8 +84,6 @@ class CollectionTest extends QlessTestCase
 
     /**
      * @test
-     *
-     *
      */
     public function shouldThrowExceptionOnSettingProperty(): void
     {
@@ -93,7 +93,9 @@ class CollectionTest extends QlessTestCase
         $collection['foo'] = 'bar';
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function shouldRemoveWorker(): void
     {
         $collection = new Collection($this->client);
@@ -108,7 +110,9 @@ class CollectionTest extends QlessTestCase
         self::assertEmpty($collection->counts);
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function shouldGetWorkersCount(): void
     {
         $collection = new Collection($this->client);
@@ -120,7 +124,9 @@ class CollectionTest extends QlessTestCase
         self::assertEquals(4, $collection->getCount());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function shouldGetWorkersRange(): void
     {
         $collection = new Collection($this->client);

--- a/tests/Workers/CollectionTest.php
+++ b/tests/Workers/CollectionTest.php
@@ -2,6 +2,8 @@
 
 namespace Qless\Tests\Workers;
 
+use Qless\Exceptions\UnknownPropertyException;
+use Qless\Exceptions\UnsupportedFeatureException;
 use Qless\Queues\Queue;
 use Qless\Tests\QlessTestCase;
 use Qless\Workers\Collection;
@@ -14,113 +16,120 @@ use Qless\Workers\Collection;
 class CollectionTest extends QlessTestCase
 {
     /** @test */
-    public function shouldGetWorkersList()
+    public function shouldGetWorkersList(): void
     {
         $collection = new Collection($this->client);
 
-        $this->assertEquals([], $collection->counts);
+        self::assertEquals([], $collection->counts);
         $this->client->pop('test-queue', 'w1', 1);
-        $this->assertEquals([['stalled' => 0, 'name' => 'w1', 'jobs' => 0]], $collection->counts);
+        self::assertEquals([['stalled' => 0, 'name' => 'w1', 'jobs' => 0]], $collection->counts);
     }
 
     /**
      * @test
-     * @expectedException \Qless\Exceptions\UnknownPropertyException
-     * @expectedExceptionMessage Getting unknown property: Qless\Workers\Collection::foo
+     *
+     *
      */
-    public function shouldThrowExceptionWhenGetInaccessibleProperty()
+    public function shouldThrowExceptionWhenGetInaccessibleProperty(): void
     {
+        $this->expectExceptionMessage("Getting unknown property: Qless\Workers\Collection::foo");
+        $this->expectException(UnknownPropertyException::class);
         $collection = new Collection($this->client);
+        /** @noinspection PhpUndefinedFieldInspection */
         $collection->foo;
     }
 
     /** @test */
-    public function shouldCheckWhetherAOffsetExists()
+    public function shouldCheckWhetherAOffsetExists(): void
     {
         $collection = new Collection($this->client);
 
-        $this->assertFalse(isset($collection['foo']));
-        $this->assertFalse(isset($collection['bar']));
+        self::assertFalse(isset($collection['foo']));
+        self::assertFalse(isset($collection['bar']));
 
         $this->client->pop('test-queue', 'foo', 1);
 
-        $this->assertTrue(isset($collection['foo']));
-        $this->assertFalse(isset($collection['bar']));
+        self::assertTrue(isset($collection['foo']));
+        self::assertFalse(isset($collection['bar']));
     }
 
     /** @test */
-    public function shouldGetWorker()
+    public function shouldGetWorker(): void
     {
         $collection = new Collection($this->client);
 
-        $this->assertEquals(['stalled' => [], 'jobs' => []], $collection['w1']);
+        self::assertEquals(['stalled' => [], 'jobs' => []], $collection['w1']);
 
         $queue = new Queue('test-queue', $this->client);
         $queue->put('Sample', [], 'jid');
         $queue->pop('w1');
 
-        $this->assertEquals(['stalled' => [], 'jobs' => ['jid']], $collection['w1']);
+        self::assertEquals(['stalled' => [], 'jobs' => ['jid']], $collection['w1']);
     }
 
     /**
      * @test
-     * @expectedException \Qless\Exceptions\UnsupportedFeatureException
-     * @expectedExceptionMessage Deleting a worker is not supported using Workers collection.
+     *
+     *
      */
-    public function shouldThrowExceptionOnDeletingProperty()
+    public function shouldThrowExceptionOnDeletingProperty(): void
     {
+        $this->expectExceptionMessage("Deleting a worker is not supported using Workers collection.");
+        $this->expectException(UnsupportedFeatureException::class);
         $collection = new Collection($this->client);
         unset($collection['foo']);
     }
 
     /**
      * @test
-     * @expectedException \Qless\Exceptions\UnsupportedFeatureException
-     * @expectedExceptionMessage Setting a worker is not supported using Workers collection.
+     *
+     *
      */
-    public function shouldThrowExceptionOnSettingProperty()
+    public function shouldThrowExceptionOnSettingProperty(): void
     {
+        $this->expectExceptionMessage("Setting a worker is not supported using Workers collection.");
+        $this->expectException(UnsupportedFeatureException::class);
         $collection = new Collection($this->client);
         $collection['foo'] = 'bar';
     }
 
     /** @test */
-    public function shouldRemoveWorker()
+    public function shouldRemoveWorker(): void
     {
         $collection = new Collection($this->client);
 
-        $this->assertEquals(['stalled' => [], 'jobs' => []], $collection['w1']);
+        self::assertEquals(['stalled' => [], 'jobs' => []], $collection['w1']);
 
         $queue = new Queue('test-queue', $this->client);
         $queue->put('Sample', [], 'jid');
         $queue->pop('w1');
 
-        $this->assertTrue($collection->remove('w1'));
-        $this->assertEmpty($collection->counts);
+        self::assertTrue($collection->remove('w1'));
+        self::assertEmpty($collection->counts);
     }
 
     /** @test */
-    public function shouldGetWorkersCount()
+    public function shouldGetWorkersCount(): void
     {
         $collection = new Collection($this->client);
 
-        $this->assertEquals(0, $collection->getCount());
+        self::assertEquals(0, $collection->getCount());
 
         $this->startFourWorkers();
 
-        $this->assertEquals(4, $collection->getCount());
+        self::assertEquals(4, $collection->getCount());
     }
 
     /** @test */
-    public function shouldGetWorkersRange()
+    public function shouldGetWorkersRange(): void
     {
         $collection = new Collection($this->client);
 
-        $this->assertEquals([], $collection->getRange(0, -1));
+        self::assertEquals([], $collection->getRange(0, -1));
 
         $this->startFourWorkers();
 
-        $this->assertEquals(
+        self::assertEquals(
             [
                 ['stalled' => 0, 'name' => 'fourth-worker', 'jobs' => 1],
                 ['stalled' => 0, 'name' => 'third-worker', 'jobs' => 1],
@@ -128,7 +137,7 @@ class CollectionTest extends QlessTestCase
             $collection->getRange(0, 1)
         );
 
-        $this->assertEquals(
+        self::assertEquals(
             [
                 ['stalled' => 0, 'name' => 'second-worker', 'jobs' => 1],
                 ['stalled' => 0, 'name' => 'first-worker', 'jobs' => 1],
@@ -137,7 +146,7 @@ class CollectionTest extends QlessTestCase
         );
     }
 
-    private function startFourWorkers()
+    private function startFourWorkers(): void
     {
         $queue = new Queue('first-queue', $this->client);
         $queue->put('First', [], 'jid1');

--- a/tests/Workers/WorkerLimitTest.php
+++ b/tests/Workers/WorkerLimitTest.php
@@ -11,38 +11,38 @@ use Qless\Workers\ForkingWorker;
 
 class WorkerLimitTest extends QlessTestCase
 {
-    public function testNumberJobs()
+    public function testNumberJobs(): void
     {
         $queue = $this->getQueue();
         $worker = $this->getWorker();
         $worker->setMaximumNumberJobs(1);
         $worker->run();
 
-        $this->assertEquals(99, $queue->length());
+        self::assertEquals(99, $queue->length());
     }
 
-    public function testTimeLimitWorker()
+    public function testTimeLimitWorker(): void
     {
         $queue = $this->getQueue();
         $worker = $this->getWorker();
         $worker->setTimeLimit(1);
         $worker->run();
 
-        $this->assertNotEmpty($queue->length());
+        self::assertNotEmpty($queue->length());
     }
 
-    public function testMemoryLimitWorker()
+    public function testMemoryLimitWorker(): void
     {
         $queue = $this->getQueue();
         $worker = $this->getWorker();
         $worker->setMemoryLimit(1);
         $worker->run();
 
-        $this->assertNotEmpty($queue->length());
+        self::assertNotEmpty($queue->length());
     }
 
 
-    private function getQueue()
+    private function getQueue(): Queue
     {
         $queue = new Queue('test-queue', $this->client);
         for ($i = 0; $i < 100; $i++) {
@@ -52,7 +52,7 @@ class WorkerLimitTest extends QlessTestCase
         return $queue;
     }
 
-    private function getWorker()
+    private function getWorker(): ForkingWorker
     {
         return new ForkingWorker(
             new OrderedReserver($this->client->queues, ['test-queue']),

--- a/tests/pubsubmanager-jobactions.php
+++ b/tests/pubsubmanager-jobactions.php
@@ -19,13 +19,13 @@ array_shift($_SERVER['argv']);
 $eventType = array_shift($_SERVER['argv']);
 $expectedJID = array_shift($_SERVER['argv']);
 
-\fprintf(STDERR, 'Waiting for Event type "%s" for jid "%s" in process %d'. PHP_EOL, $eventType, $expectedJID, $pid);
+fprintf(STDERR, 'Waiting for Event type "%s" for jid "%s" in process %d'. PHP_EOL, $eventType, $expectedJID, $pid);
 
 $pubSubManager->on(
     $eventType,
     static function ($jid) use ($eventType, $expectedJID, $pid, $pubSubManager) {
-        \printf('%s: %s' . PHP_EOL, $eventType, $jid);
-        \fprintf(STDERR, 'Got Event type "%s" for jid "%s" in process %d'. PHP_EOL, $eventType, $jid, $pid);
+        printf('%s: %s' . PHP_EOL, $eventType, $jid);
+        fprintf(STDERR, 'Got Event type "%s" for jid "%s" in process %d'. PHP_EOL, $eventType, $jid, $pid);
         if ($jid === $expectedJID) {
             $pubSubManager->stopListening();
             exit(0);
@@ -37,12 +37,12 @@ while (true) {
     try {
         $pubSubManager->listen();
     } catch (ConnectionException $exception) {
-        \fwrite(STDERR, $exception->getMessage() . PHP_EOL);
-        \fwrite(STDERR, 'Reconnecting to Redis' . PHP_EOL);
+        fwrite(STDERR, $exception->getMessage() . PHP_EOL);
+        fwrite(STDERR, 'Reconnecting to Redis' . PHP_EOL);
         $client->reconnect();
         continue;
-    } catch (\Throwable $exception) {
-        \fwrite(STDERR, $exception->getMessage() . PHP_EOL);
+    } catch (Throwable $exception) {
+        fwrite(STDERR, $exception->getMessage() . PHP_EOL);
         exit(1);
     }
 }

--- a/tests/simple-bench
+++ b/tests/simple-bench
@@ -86,7 +86,7 @@ function histogram($l) {
     $l = array_values(array_filter($l));
 
     foreach (range(0, count($l) - 1) as $i) {
-        fprintf(STDOUT, "\t\t%2d, %10.9f, %d" . PHP_EOL, $i, floatval($l[$i]) / $count, $l[$i]);
+        fprintf(STDOUT, "\t\t%2d, %10.9f, %d" . PHP_EOL, $i, (float) $l[$i] / $count, $l[$i]);
     }
 }
 


### PR DESCRIPTION
Hello!

* Type: code quality

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)?
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I wrote some tests for this PR.

Small description of change:

Updates a number of tests that were using deprecated call types (static vs instance), and relying on doc block annotations to indicate expected exceptions etc, to use non-deprecated methods. 
Also cleans up some syntax stuff that causes a bunch of inspection notices in IDEs - i.e. declaring methods void, etc.
Some (notably calls to `TestCase::expectExceptionMessageRegExp` are themselves later deprecated in favour of a different named method, but the new method is only available as of PHPUnit 8.4.0, and thus they use the method-based approach, but use the older method name.

Thanks
