### PR TITLE
Change BaseJob::heartbeat() signature to match other binding defaults

### DIFF
--- a/src/Jobs/BaseJob.php
+++ b/src/Jobs/BaseJob.php
@@ -387,13 +387,13 @@ class BaseJob extends AbstractJob implements \ArrayAccess
      *
      * @throws LostLockException
      */
-    public function heartbeat(array $data = []): float
+    public function heartbeat(?array $data = null): float
     {
         try {
             $this->expires = $this->client->heartbeat(
                 $this->jid,
                 $this->worker,
-                json_encode($data, JSON_UNESCAPED_SLASHES)
+                json_encode(\is_array($data) ? $data : $this->data, JSON_UNESCAPED_SLASHES)
             );
         } catch (QlessException $e) {
             throw new LostLockException($e->getMessage(), 'Heartbeat', $this->jid, $e->getCode(), $e);

--- a/tests/Jobs/BaseJobTest.php
+++ b/tests/Jobs/BaseJobTest.php
@@ -242,6 +242,38 @@ class BaseJobTest extends QlessTestCase
         self::assertTrue($job->ttl() > $before);
     }
 
+   /**
+     * @test
+     */
+    public function shouldDefaultToCurrentDataDuringHeartbeat(): void
+    {
+        $jobData = ['foo' => 'bar'];
+        $this->client->queues['foo']->put('Foo', $jobData, 'jid');
+
+        $job = $this->client->queues['foo']->pop();
+
+        $job->heartbeat();
+
+        self::assertSame($jobData, $this->client->jobs['jid']->getData()->toArray());
+    }
+
+   /**
+     * @test
+     */
+    public function shouldRecordNewDataDuringHeartbeat(): void
+    {
+        $jobData = ['foo' => 'bar'];
+        $this->client->queues['foo']->put('Foo', $jobData, 'jid');
+
+        $job = $this->client->queues['foo']->pop();
+
+        $jobData2 = ['baz' => 'foo-bar'];
+
+        $job->heartbeat($jobData2);
+
+        self::assertSame($jobData2, $this->client->jobs['jid']->getData()->toArray());
+    }
+
     /**
      * @test
      */


### PR DESCRIPTION
Hello!

* Type: bug fix
* Link to issue: #116

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)?
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I wrote some tests for this PR.

Other bindings for Qless (Ruby, Python, JS) don't support updating the job data at all when heart-beating.
As this behaviour over what other implementations do may be useful in existing projects, we shouldn't remove the support for it, instead, we should change it to use current data by default.

Closes #116

Thanks
