### PR TITLE
Ensure Queue::recur creates a JID consistent with Queue::put

### DIFF
--- a/src/Queues/Queue.php
+++ b/src/Queues/Queue.php
@@ -202,7 +202,7 @@ class Queue implements EventsManagerAwareInterface
         ?array $tags = null
     ): string {
         try {
-            $jid = $jid ?: Uuid::uuid4()->toString();
+            $jid = $jid ?: str_replace('-', '', Uuid::uuid4()->toString());
         } catch (\Exception $e) {
             throw new RuntimeException($e->getMessage(), $e->getCode(), $e);
         }

--- a/tests/Queues/QueueTest.php
+++ b/tests/Queues/QueueTest.php
@@ -35,6 +35,7 @@ class QueueTest extends QlessTestCase
     {
         $queue = new Queue('test-queue', $this->client);
         self::assertRegExp('/^[[:xdigit:]]{32}$/', $queue->put('Xxx\Yyy', []));
+        self::assertRegExp('/^[[:xdigit:]]{32}$/', $queue->recur('Xxx\Yyy', []));
     }
 
     /**


### PR DESCRIPTION
Hello!

* Type: bug fix
* Link to issue:

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)?
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I wrote some tests for this PR.

Small description of change:

Makes `Queue::recur` return a JID in the same format (i.e. without hyphens) as `Queue::put`.

Thanks
