### PR TITLE
Allow Worker subclasses to re-define signal handling.

### DIFF
--- a/README.md
+++ b/README.md
@@ -331,6 +331,8 @@ When using the Non-Forking worker, proper handling of `USR1` signals requires th
 catches all Exceptions or all Throwables, you will need to re-throw instances of
 `\Qless\Exceptions\SimpleWorkerContinuationException`, or `USR1` signals will be ignored.
 
+If you wish to change how signals are handled, you can sub-class the `Worker` class you wish to use, and override the `handleSignal` method.
+
 #### Job Reservers
 
 There are different job reservers.

--- a/src/Subscribers/SignalsAwareSubscriber.php
+++ b/src/Subscribers/SignalsAwareSubscriber.php
@@ -82,24 +82,7 @@ class SignalsAwareSubscriber
                     'signal' => $signalName,
                 ]);
 
-                switch ($signal) {
-                    case SIGTERM:
-                    case SIGINT:
-                        $worker->shutDownNow();
-                        break;
-                    case SIGQUIT:
-                        $worker->shutdown();
-                        break;
-                    case SIGUSR1:
-                        $worker->killChildren();
-                        break;
-                    case SIGUSR2:
-                        $worker->pauseProcessing();
-                        break;
-                    case SIGCONT:
-                        $worker->unPauseProcessing();
-                        break;
-                }
+                $worker->handleSignal($signal, $signalName, $this);
             }
         );
     }

--- a/src/Workers/WorkerInterface.php
+++ b/src/Workers/WorkerInterface.php
@@ -6,6 +6,7 @@ use Psr\Log\LoggerAwareInterface;
 use Qless\Exceptions\RuntimeException;
 use Qless\Jobs\BaseJob;
 use Qless\Jobs\PerformAwareInterface;
+use Qless\Subscribers\SignalsAwareSubscriber;
 
 /**
  * Qless\Workers\WorkerInterface
@@ -110,4 +111,13 @@ interface WorkerInterface extends LoggerAwareInterface
      * @return void
      */
     public function unPauseProcessing(): void;
+
+    /**
+     * Handle a Signal
+     *
+     * @param int $signal
+     * @param string $signalName
+     * @param SignalsAwareSubscriber $signalsAwareSubscriber
+     */
+    public function handleSignal(int $signal, string $signalName, SignalsAwareSubscriber $signalsAwareSubscriber): void;
 }

--- a/tests/Stubs/CustomSignalWorker.php
+++ b/tests/Stubs/CustomSignalWorker.php
@@ -1,0 +1,96 @@
+<?php
+
+namespace Qless\Tests\Stubs;
+
+use Qless\Events\User\Worker\AbstractWorkerEvent;
+use Qless\Subscribers\SignalsAwareSubscriber;
+use Qless\Tests\Support\SignalWorkerTrait;
+use Qless\Workers\AbstractWorker;
+
+/**
+ * Qless\Tests\Stubs\CustomSignalWorker
+ *
+ * @package Qless\Tests\Stubs
+ */
+class CustomSignalWorker extends AbstractWorker implements SignalWorker
+{
+
+    use SignalWorkerTrait;
+
+    public function onConstruct(): void
+    {
+        $this->getEventsManager()->attach(
+            AbstractWorkerEvent::getEntityName(),
+            new SignalsAwareSubscriber($this->logger)
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function perform(): void
+    {
+    }
+
+    public function doSigTerm(): void
+    {
+        $this->setLastSignalAction(__FUNCTION__);
+    }
+
+    public function doSigInt(): void
+    {
+        $this->setLastSignalAction(__FUNCTION__);
+    }
+
+    public function doSigQuit(): void
+    {
+        $this->setLastSignalAction(__FUNCTION__);
+    }
+
+    public function doSigUsr1(): void
+    {
+        $this->setLastSignalAction(__FUNCTION__);
+    }
+
+    public function doSigUsr2(): void
+    {
+        $this->setLastSignalAction(__FUNCTION__);
+    }
+
+    public function doSigCont(): void
+    {
+        $this->setLastSignalAction(__FUNCTION__);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function handleSignal(int $signal, string $signalName, SignalsAwareSubscriber $signalsAwareSubscriber): void
+    {
+        switch ($signal) {
+            case SIGTERM:
+                $this->doSigTerm();
+                break;
+
+            case SIGINT:
+                $this->doSigInt();
+                break;
+
+            case SIGQUIT:
+                $this->doSigQuit();
+                break;
+
+            case SIGUSR1:
+                $this->doSigUsr1();
+                break;
+
+            case SIGUSR2:
+                $this->doSigUsr2();
+                break;
+
+            case SIGCONT:
+                $this->doSigCont();
+                break;
+        }
+    }
+}

--- a/tests/Stubs/DefaultSignalWorker.php
+++ b/tests/Stubs/DefaultSignalWorker.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Qless\Tests\Stubs;
+
+use Qless\Events\User\Job as JobEvent;
+use Qless\Subscribers\SignalsAwareSubscriber;
+use Qless\Tests\Support\SignalWorkerTrait;
+use Qless\Workers\AbstractWorker;
+use RuntimeException;
+
+/**
+ * Qless\Tests\Stubs\DefaultSignalWorker
+ *
+ * @package Qless\Tests\Stubs
+ */
+class DefaultSignalWorker extends AbstractWorker implements SignalWorker
+{
+
+    use SignalWorkerTrait;
+
+    /** @var SignalsAwareSubscriber */
+    private $signalsSubscriber;
+
+    public function onConstruct(): void
+    {
+        $this->signalsSubscriber = new SignalsAwareSubscriber($this->logger);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function perform(): void
+    {
+    }
+
+
+    public function shutdownNow(): void
+    {
+        $this->setLastSignalAction(__FUNCTION__);
+    }
+
+    public function shutdown(): void
+    {
+        $this->setLastSignalAction(__FUNCTION__);
+    }
+
+    public function killChildren(): void
+    {
+        $this->setLastSignalAction(__FUNCTION__);
+    }
+
+    public function pauseProcessing(): void
+    {
+        $this->setLastSignalAction(__FUNCTION__);
+    }
+
+    public function unPauseProcessing(): void
+    {
+        $this->setLastSignalAction(__FUNCTION__);
+    }
+
+}

--- a/tests/Stubs/DefaultSignalWorker.php
+++ b/tests/Stubs/DefaultSignalWorker.php
@@ -2,11 +2,10 @@
 
 namespace Qless\Tests\Stubs;
 
-use Qless\Events\User\Job as JobEvent;
+use Qless\Events\User\Worker\AbstractWorkerEvent;
 use Qless\Subscribers\SignalsAwareSubscriber;
 use Qless\Tests\Support\SignalWorkerTrait;
 use Qless\Workers\AbstractWorker;
-use RuntimeException;
 
 /**
  * Qless\Tests\Stubs\DefaultSignalWorker
@@ -18,12 +17,12 @@ class DefaultSignalWorker extends AbstractWorker implements SignalWorker
 
     use SignalWorkerTrait;
 
-    /** @var SignalsAwareSubscriber */
-    private $signalsSubscriber;
-
     public function onConstruct(): void
     {
-        $this->signalsSubscriber = new SignalsAwareSubscriber($this->logger);
+        $this->getEventsManager()->attach(
+            AbstractWorkerEvent::getEntityName(),
+            new SignalsAwareSubscriber($this->logger)
+        );
     }
 
     /**
@@ -58,5 +57,4 @@ class DefaultSignalWorker extends AbstractWorker implements SignalWorker
     {
         $this->setLastSignalAction(__FUNCTION__);
     }
-
 }

--- a/tests/Stubs/SignalWorker.php
+++ b/tests/Stubs/SignalWorker.php
@@ -2,12 +2,10 @@
 
 namespace Qless\Tests\Stubs;
 
-use Qless\Events\User\Job as JobEvent;
-use Qless\Subscribers\SignalsAwareSubscriber;
-use Qless\Workers\AbstractWorker;
-use RuntimeException;
+use Qless\Workers\WorkerInterface;
 
-interface SignalWorker
+interface SignalWorker extends WorkerInterface
 {
+
     public function getLastSignalAction();
 }

--- a/tests/Stubs/SignalWorker.php
+++ b/tests/Stubs/SignalWorker.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Qless\Tests\Stubs;
+
+use Qless\Events\User\Job as JobEvent;
+use Qless\Subscribers\SignalsAwareSubscriber;
+use Qless\Workers\AbstractWorker;
+use RuntimeException;
+
+interface SignalWorker
+{
+    public function getLastSignalAction();
+}

--- a/tests/Support/BackgroundProcessTrait.php
+++ b/tests/Support/BackgroundProcessTrait.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Qless\Tests\Support;
+
+use Predis\Client as Redis;
+
+/**
+ * Qless\Tests\Support\RedisAwareTrait
+ *
+ * @package Qless\Tests
+ */
+trait RedisAwareTrait
+{
+    /** @var Redis */
+    private $instance;
+
+    /**
+     * Gets the Redis instance.
+     *
+     * @param  bool $recreate
+     * @return Redis
+     */
+    protected function redis(bool $recreate = false): Redis
+    {
+        if ($this->instance instanceof Redis === false || $recreate === true) {
+            $config = $this->getRedisConfig();
+
+            $this->instance = new Redis(
+                [
+                    'scheme' => $config['scheme'],
+                    'host'   => $config['host'],
+                    'port'   => $config['port'],
+                ]
+            );
+
+            $this->instance->connect();
+        }
+
+        return $this->instance;
+    }
+
+    /**
+     * Gets the Redis configuration.
+     *
+     * @param array $overrides
+     * @return array
+     */
+    protected function getRedisConfig(array $overrides = []): array
+    {
+        return array_merge([
+            'host'   => REDIS_HOST,
+            'port'   => REDIS_PORT,
+            'scheme' => 'tcp',
+        ], $overrides);
+    }
+}

--- a/tests/Support/SignalWorkerTrait.php
+++ b/tests/Support/SignalWorkerTrait.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Qless\Tests\Support;
+
+use Qless\Tests\Stubs\DefaultSignalWorker;
+
+/**
+ * Qless\Tests\Support\SignalWorkerTrait
+ *
+ * @package Qless\Tests
+ */
+trait SignalWorkerTrait
+{
+
+    /**
+     * @var string|null
+     */
+    protected $lastSignalAction = null;
+
+    protected function setLastSignalAction(string $lastSignalAction): void
+    {
+        $this->lastSignalAction = $lastSignalAction;
+    }
+
+    public function getLastSignalAction(): ?string
+    {
+        return $this->lastSignalAction;
+    }
+}

--- a/tests/Workers/CustomWorkerSignalTest.php
+++ b/tests/Workers/CustomWorkerSignalTest.php
@@ -3,27 +3,27 @@
 namespace Qless\Tests\Workers;
 
 use Qless\Jobs\Reservers\OrderedReserver;
-use Qless\Tests\Stubs\DefaultSignalWorker;
+use Qless\Tests\Stubs\CustomSignalWorker;
 use Qless\Tests\Stubs\SignalWorker;
 
-class DefaultWorkerSignalTest extends WorkerSignalTest
+class CustomWorkerSignalTest extends WorkerSignalTest
 {
 
     public function signalDataProvider(): array
     {
         return [
-            [\SIGTERM, 'shutdownNow'],
-            [\SIGINT, 'shutdownNow'],
-            [\SIGQUIT, 'shutdown'],
-            [\SIGUSR1, 'killChildren'],
-            [\SIGUSR2, 'pauseProcessing'],
-            [\SIGCONT, 'unPauseProcessing']
+            [\SIGTERM, 'doSigTerm'],
+            [\SIGINT, 'doSigInt'],
+            [\SIGQUIT, 'doSigQuit'],
+            [\SIGUSR1, 'doSigUsr1'],
+            [\SIGUSR2, 'doSigUsr2'],
+            [\SIGCONT, 'doSigCont']
         ];
     }
 
     protected function getWorker(): SignalWorker
     {
-        return new DefaultSignalWorker(
+        return new CustomSignalWorker(
             new OrderedReserver($this->client->queues, ['test-queue']),
             $this->client
         );

--- a/tests/Workers/DefaultWorkerSignalTest.php
+++ b/tests/Workers/DefaultWorkerSignalTest.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Qless\Tests\Workers;
+
+use Qless\Jobs\Reservers\AbstractReserver;
+use Qless\Jobs\Reservers\OrderedReserver;
+use Qless\Tests\Stubs\DefaultSignalWorker;
+use Qless\Workers\AbstractWorker;
+use Qless\Workers\ResourceLimitedWorkerInterface;
+use Qless\Workers\SimpleWorker;
+
+class DefaultWorkerSignalTest extends WorkerSignalTest
+{
+    protected function getWorker(): DefaultSignalWorker
+    {
+        return new DefaultSignalWorker(
+            new OrderedReserver($this->client->queues, ['test-queue']),
+            $this->client
+        );
+    }
+}

--- a/tests/Workers/WorkerSignalTest.php
+++ b/tests/Workers/WorkerSignalTest.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Qless\Tests\Workers;
+
+use Qless\Jobs\Reservers\AbstractReserver;
+use Qless\Jobs\Reservers\OrderedReserver;
+use Qless\Tests\QlessTestCase;
+use Qless\Signals\SignalHandler;
+use Qless\Tests\Stubs\DefaultSignalWorker;
+use Qless\Tests\Stubs\SignalWorker;
+use Qless\Workers\AbstractWorker;
+use Qless\Workers\WorkerInterface;
+
+/**
+ * Qless\Tests\Workers\WorkerSignalTest
+ *
+ * @package Qless\Tests\Workers
+ */
+abstract class WorkerSignalTest extends QlessTestCase
+{
+
+    abstract protected function getWorker(): SignalWorker;
+
+    /**
+     * @test
+     * @dataProvider signalDataProvider
+     *
+     * @param int    $signal
+     * @param string $expected
+     */
+    public function shouldGetSignalName(int $signal, string $expected): void
+    {
+        $worker = $this->getWorker();
+
+        \posix_kill(\posix_getpid(), $signal);
+
+        self::assertEquals($expected, $worker->getLastSignalAction());
+    }
+
+    public function signalDataProvider(): array
+    {
+        return [
+            [\SIGTERM, 'shutDownNow'],
+            [\SIGINT, 'shutDownNow'],
+            [\SIGQUIT, 'shutdown'],
+            [\SIGUSR1, 'killChildren'],
+            [\SIGUSR2, 'pauseProcessing'],
+            [\SIGCONT, 'unPauseProcessing']
+        ];
+    }
+}

--- a/tests/Workers/WorkerSignalTest.php
+++ b/tests/Workers/WorkerSignalTest.php
@@ -2,14 +2,8 @@
 
 namespace Qless\Tests\Workers;
 
-use Qless\Jobs\Reservers\AbstractReserver;
-use Qless\Jobs\Reservers\OrderedReserver;
 use Qless\Tests\QlessTestCase;
-use Qless\Signals\SignalHandler;
-use Qless\Tests\Stubs\DefaultSignalWorker;
 use Qless\Tests\Stubs\SignalWorker;
-use Qless\Workers\AbstractWorker;
-use Qless\Workers\WorkerInterface;
 
 /**
  * Qless\Tests\Workers\WorkerSignalTest
@@ -21,31 +15,23 @@ abstract class WorkerSignalTest extends QlessTestCase
 
     abstract protected function getWorker(): SignalWorker;
 
+    abstract public function signalDataProvider(): array;
+
     /**
      * @test
      * @dataProvider signalDataProvider
      *
-     * @param int    $signal
+     * @param int $signal
      * @param string $expected
      */
-    public function shouldGetSignalName(int $signal, string $expected): void
+    public function shouldHandleSignalAction(int $signal, string $expected): void
     {
         $worker = $this->getWorker();
+
+        $worker->run();
 
         \posix_kill(\posix_getpid(), $signal);
 
         self::assertEquals($expected, $worker->getLastSignalAction());
-    }
-
-    public function signalDataProvider(): array
-    {
-        return [
-            [\SIGTERM, 'shutDownNow'],
-            [\SIGINT, 'shutDownNow'],
-            [\SIGQUIT, 'shutdown'],
-            [\SIGUSR1, 'killChildren'],
-            [\SIGUSR2, 'pauseProcessing'],
-            [\SIGCONT, 'unPauseProcessing']
-        ];
     }
 }


### PR DESCRIPTION
Closes #128

Hello!

* Type: new feature
* Link to issue: #128

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)?
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I wrote some tests for this PR.

Small description of change:

This allows worker classes to override the default handling of received signals.

Thanks
