### PR TITLE
[CORE-3728] tags list of all jobs

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -45,6 +45,7 @@ use Predis\Client as Redis;
  * @method string workers(?string $workerName = null, ?int $start = null, ?int $last = null)
  * @method string workerJobs(string $worker, ?int $minScoreTime = null)
  * @method string subscription(string $queue, $op, $topic)
+ * @method string tags(int $offset, int $count)
  *
  * @property-read JobsCollection $jobs
  * @property-read WorkersCollection $workers

--- a/src/Jobs/Collection.php
+++ b/src/Jobs/Collection.php
@@ -87,8 +87,8 @@ class Collection implements ArrayAccess
      * Fetches a report of failed jobs for the specified group
      *
      * @param string|bool $group
-     * @param int         $start
-     * @param int         $limit
+     * @param int $start
+     * @param int $limit
      *
      * @return array
      */
@@ -228,5 +228,16 @@ class Collection implements ArrayAccess
     public function offsetUnset($offset)
     {
         throw new UnsupportedFeatureException('Deleting a job is not supported using Jobs collection.');
+    }
+
+    /**
+     * @param int $offset
+     * @param int $count
+     *
+     * @return array
+     */
+    public function tagsList(int $offset = 0, int $count = 10000): array
+    {
+        return json_decode($this->client->tags($offset, $count), true) ?: [];
     }
 }

--- a/src/qless-core/qless.lua
+++ b/src/qless-core/qless.lua
@@ -189,6 +189,16 @@ function Qless.subscription(now, queue, command, topic)
   end
 end
 
+function Qless.tags(cursor, count)
+  local tags = redis.call('scan', cursor, 'match', 'ql:t:*', 'count', count)
+
+  for i=1,#tags[2] do
+    tags[2][i] = tags[2][i]:gsub("ql:t:", "")
+  end
+
+  return tags[2]
+end
+
 function Qless.tag(now, command, ...)
   assert(command,
     'Tag(): Arg "command" must be "add", "remove", "get" or "top"')
@@ -2192,6 +2202,10 @@ end
 
 QlessAPI.track = function(now, command, jid)
   return cjson.encode(Qless.track(now, command, jid))
+end
+
+QlessAPI.tags = function(now, cursor, count)
+  return cjson.encode(Qless.tags(cursor, count))
 end
 
 QlessAPI.tag = function(now, command, ...)

--- a/tests/Jobs/CollectionTest.php
+++ b/tests/Jobs/CollectionTest.php
@@ -260,6 +260,18 @@ class CollectionTest extends QlessTestCase
         self::assertCount(3, $jobs);
     }
 
+    public function testTagsList(): void
+    {
+        $queue = $this->client->queues['test-queue'];
+        $queue->put('SampleJobPerformClass', [], 'jid-1', 0, 0, 0, ['tag-a', 'tag-b']);
+        $queue->put('SampleJobPerformClass', [], 'jid-2', 0, 0, 0, ['tag-a', 'tag-c']);
+
+        $data = $this->client->jobs->tagsList();
+        sort($data);
+
+        self::assertEquals(['tag-a', 'tag-b', 'tag-c'], $data);
+    }
+
 
     private function put($jid, $opts = []): void
     {


### PR DESCRIPTION
Hello!

* Type: new feature
* Link to issue:

**In raising this pull request, I confirm the following (please check boxes):**

- [ ] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)?
- [ ] I have checked that another pull request for this purpose does not exist.
- [ ] I wrote some tests for this PR.

Small description of change:

In this pull-request was adding method which allows to get full list of tags of the jobs without getting collection of jobs.

Thanks
