### PR TITLE
Fix (offset, count) parameters on `queue.work.peek`

### DIFF
--- a/src/qless-core/qless.lua
+++ b/src/qless-core/qless.lua
@@ -1095,7 +1095,7 @@ function Qless.queue(name)
       end
       local indexStart = offset
       if indexStart == nil then
-        indexStart = 1
+        indexStart = 0
       end
       local jids = {}
       local indexEnd = indexStart + count - 1

--- a/src/qless-core/qless.lua
+++ b/src/qless-core/qless.lua
@@ -1093,12 +1093,15 @@ function Qless.queue(name)
       if count == 0 then
         return {}
       end
-      if offset == nil then
-        offset = 0
+      local indexStart = offset
+      if indexStart == nil then
+        indexStart = 1
       end
       local jids = {}
-      for index, jid in ipairs(redis.call(
-        'zrevrange', queue:prefix('work'), offset, count - 1)) do
+      local indexEnd = indexStart + count - 1
+      for index, jid in ipairs(
+        redis.call('zrevrange', queue:prefix('work'), indexStart, indexEnd)
+      ) do
         table.insert(jids, jid)
       end
       return jids

--- a/tests/Jobs/CollectionTest.php
+++ b/tests/Jobs/CollectionTest.php
@@ -271,28 +271,45 @@ class CollectionTest extends QlessTestCase
         ];
     }
 
-    private const TEST_JOBS_COUNT = 15;
-
     /**
      * @dataProvider returnCorrectWaitingJobsDataProvider
      */
-    public function testReturnCorrectWaitingJobsOnCountSmallerThenOffsetWithoutParameters(int $offset, int $count): void
+    public function testReturnCorrectWaitingJobsOnCountSmallerThenOffsetWithParameters(int $offset, int $count): void
     {
-        $queueName = 'test_waiting_queue';
-        $jobPrefix = 'job-test-return-correct-waiting-jobs-';
+        $queueName = 'test_waiting_queue_with_parameters';
+        $jobPrefix = 'job-test-return-correct-waiting-jobs-with-parameters-';
 
         $queue = new Queue($queueName, $this->client);
 
-        for ($i = 0; $i < self::TEST_JOBS_COUNT; $i++) {
+        $testJobsCount = 15;
+        for ($i = 0; $i < $testJobsCount; $i++) {
             $queue->put('Xxx\Yyy', ['test' => 'some-data'], $jobPrefix . $i);
         }
 
         $jobIds = $this->client->jobs('waiting', $queueName, $offset, $count);
 
-        $jobsWithoutSkipped = self::TEST_JOBS_COUNT - $offset;
+        $jobsWithoutSkipped = $testJobsCount - $offset;
         $expectedJobsCount = $jobsWithoutSkipped > 0 ? min($count, $jobsWithoutSkipped) : 0;
 
         self::assertCount($expectedJobsCount, $jobIds);
+    }
+
+    public function testReturnCorrectWaitingJobsOnCountSmallerThenOffsetWithoutParameters(): void
+    {
+        $queueName = 'test_waiting_queue_without_parameters';
+        $jobPrefix = 'job-test-return-correct-waiting-jobs-without-parameters-';
+
+        $queue = new Queue($queueName, $this->client);
+
+        $testJobsCount = 30;
+        for ($i = 0; $i < $testJobsCount; $i++) {
+            $queue->put('Xxx\Yyy', ['test' => 'some-data'], $jobPrefix . $i);
+        }
+
+        $jobIds = $this->client->jobs('waiting', $queueName);
+
+        $defaultLimit = 25;
+        self::assertCount($defaultLimit, $jobIds);
     }
 
     private function put($jid, $opts = []): void


### PR DESCRIPTION
[Bugfix]

Fixed function's signature from `(start, end)` to `(offset, count)`