### PR TITLE
Updates for support PHP 8.1

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -20,7 +20,7 @@ jobs:
           --health-retries 5
     strategy:
       matrix:
-        php-versions: ['7.1', '7.2', '7.3', '7.4', '8.0']
+        php-versions: ['7.1', '7.2', '7.3', '7.4', '8.0', '8.1']
     name: PHP ${{ matrix.php-versions }}
     steps:
       - name: Checkout

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [3.15.0]
+
+### Changed
+- PHP 8.1 support
+- Bump `phpunit/phpunit` version to `^9.0`
+
 ## [3.18.0] - 2022-04-25
 ### Fixes
 - Fix (offset, count) parameters on queue.work.peek

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # qless-php
 
-[![Build Status](https://travis-ci.org/pdffiller/qless-php.svg?branch=master)](https://travis-ci.org/pdffiller/qless-php)
+[![PHP Version](https://img.shields.io/badge/supported->%3D7.1%20<%3D%208.2-blue?logo=php)](https://php.net/)
+[![Workflow Status](https://github.com/pdffiller/qless-php/actions/workflows/pr.yml/badge.svg)](https://github.com/pdffiller/qless-php/actions/workflows/pr.yml)
 [![Infection MSI](https://badge.stryker-mutator.io/github.com/pdffiller/qless-php/master)](https://infection.github.io)
 
 PHP Bindings for qless.
@@ -104,7 +105,7 @@ Prerequisite PHP extensions are:
 - [`pcre`](http://php.net/manual/en/book.pcre.php)
 - [`sockets`](http://php.net/manual/en/book.sockets.php)
 
-Supported PHP versions are: **7.1**, **7.2**, **7.3**, **8.0**.
+Supported PHP versions are: **7.1**, **7.2**, **7.3**, **8.0** and **8.1**.
 
 Qless PHP can be installed via Composer:
 
@@ -946,7 +947,7 @@ qless-php is open-sourced software licensed under the MIT License.
 See the [`LICENSE.txt`](https://github.com/pdffiller/qless-php/blob/master/LICENSE.txt) file for more.
 
 
-© 2018-2021 PDFfiller<br>
+© 2018-2022 PDFfiller<br>
 © 2013-2015 Ryver, Inc <br>
 
 All rights reserved.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # qless-php
 
-[![PHP Version](https://img.shields.io/badge/supported->%3D7.1%20<%3D%208.2-blue?logo=php)](https://php.net/)
+[![PHP Version](https://img.shields.io/badge/supported->%3D7.1%20<8.2-blue?logo=php)](https://php.net/)
 [![Workflow Status](https://github.com/pdffiller/qless-php/actions/workflows/pr.yml/badge.svg)](https://github.com/pdffiller/qless-php/actions/workflows/pr.yml)
 [![Infection MSI](https://badge.stryker-mutator.io/github.com/pdffiller/qless-php/master)](https://infection.github.io)
 

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         }
     ],
     "require": {
-        "php": ">=7.1 <8.1",
+        "php": ">=7.1 <= 8.2",
         "ext-json": "*",
         "ext-pcntl": "*",
         "ext-pcre": "*",
@@ -41,7 +41,7 @@
     },
     "require-dev": {
         "phpstan/phpstan": "^0.12.87",
-        "phpunit/phpunit": "^7.5 || ^8.5",
+        "phpunit/phpunit": "^7.5 || ^8.5 || ^9.0",
         "squizlabs/php_codesniffer": "3.*"
     },
     "suggest": {

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         }
     ],
     "require": {
-        "php": ">=7.1 <= 8.2",
+        "php": ">=7.1 < 8.2",
         "ext-json": "*",
         "ext-pcntl": "*",
         "ext-pcre": "*",


### PR DESCRIPTION
Hello!

* Type: new feature
* Link to issue: -

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)?
- [x] I have checked that another pull request for this purpose does not exist.
- [ ] I wrote some tests for this PR. - No, just add running tests for PHP 8.1

Small description of change:
Add supporting PHP 8.1 and bump `phpunit/phpunit` version.

resolves #143 